### PR TITLE
Fix HAPI LLM approval/session flow edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ hapi codex    # Open Codex
 
 | 配置项 | 说明 | 默认值 |
 |--------|------|--------|
-| `output_level` | SSE 推送级别：`silence` / `simple` / `summary` / `detail` | detail |
+| `output_level` | SSE 推送级别：`silence` / `simple` / `summary` / `detail` | simple |
 | `summary_msg_count` | summary 级别显示的 agent 消息条数 | 5 |
 | `quick_prefix` | 快捷发送前缀字符 | `>` |
 | `poke_approve` | 戳一戳自动全部审批（仅 QQ NapCat） | 开启 |
@@ -142,7 +142,7 @@ hapi codex    # Open Codex
 
 ### 🤖 LLM 工具集成（自然语言交互）
 
-插件提供 10 个 Function Calling 工具，支持用自然语言管理远程会话：
+插件提供 11 个 Function Calling 工具，支持用自然语言管理远程会话：
 
 | 工具名 | 说明 |
 |--------|------|
@@ -160,11 +160,11 @@ hapi codex    # Open Codex
 
 **使用方式**：在 Astrbot 管理面板开启工具后，直接对话即可，如"切换到1号session"、"创建一个 Claude 会话"。
 
-**推荐配置**：建议至少激活 `hapi_coding_list_commands` 和 `hapi_coding_execute_command` 两个工具。`execute_command` 可执行任意 /hapi 指令，其它工具仅为便捷性提供。
+**推荐配置**：建议至少激活 `hapi_coding_list_commands`。如需覆盖尚未封装的 `/hapi` 子命令，再启用 `hapi_coding_execute_command`；常见操作优先使用结构化工具（如切换、创建、发消息、改配置）。
 
 **审批机制**：操作类工具需管理员审批（支持 `/hapi a` 批准、`/hapi deny` 拒绝、戳一戳快速批准），防止模型误操作。
 
-**智能隔离**：工具仅在管理员且当前窗口有 HAPI 会话时注册，不污染其他聊天上下文。
+**智能隔离**：非管理员不会注册任何工具；当前窗口没有可见 HAPI 会话时，仅保留 `hapi_coding_list_sessions`、`hapi_coding_list_commands`、`hapi_coding_execute_command` 3 个基础工具，避免污染上下文。
 
 ---
 
@@ -242,7 +242,7 @@ hapi codex    # Open Codex
 | `silence` | 仅推送权限请求和等待输入提醒，其余静默 |
 | `simple` | AI 思考完成后推送纯文本 agent 消息及系统事件（过滤工具调用） |
 | `summary` | AI 思考完成后推送最近 N 条 agent 消息（N 由 summary_msg_count 控制，过滤工具调用） |
-| `detail` | 实时推送所有新消息（信息量较大，默认） |
+| `detail` | 实时推送所有新消息（信息量较大） |
 
 ---
 

--- a/approval_ops.py
+++ b/approval_ops.py
@@ -85,7 +85,7 @@ async def batch_approve(client: AsyncHapiClient,
     return results
 
 
-async def answer_question(client: AsyncHapiClient, sid: str, rid: str, answers: dict) -> bool:
+async def answer_question(client: AsyncHapiClient, sid: str, rid: str,
+                          answers: dict) -> tuple[bool, str]:
     """回答 question 类型的权限请求"""
-    ok, _ = await session_ops.answer_permission_question(client, sid, rid, answers)
-    return ok
+    return await session_ops.answer_permission_question(client, sid, rid, answers)

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -437,6 +437,7 @@ class CommandHandlers:
                 else:
                     self.sse_listener.output_level = t
                     self.plugin.config["output_level"] = t
+                    self.plugin.config.save_config()
                     await ev.send(ev.plain_result(
                         f"SSE 推送级别已切换为: {t}\n{self._OUTPUT_LEVELS[t]}"))
                 controller.stop()
@@ -461,6 +462,7 @@ class CommandHandlers:
 
         self.sse_listener.output_level = target
         self.plugin.config["output_level"] = target
+        self.plugin.config.save_config()
         yield event.plain_result(
             f"SSE 推送级别已切换为: {target}\n{self._OUTPUT_LEVELS[target]}")
 

--- a/llm_integration.py
+++ b/llm_integration.py
@@ -1,7 +1,6 @@
 """LLM 工具集成 - 为 LLM 提供 HAPI Coding Session 交互能力"""
 
 import asyncio
-import time
 from astrbot.api.event import filter, AstrMessageEvent, MessageChain
 from astrbot.api.provider import ProviderRequest
 from astrbot.api import logger
@@ -148,33 +147,31 @@ class LLMIntegration:
             logger.warning(f"LLM 工具 {tool_name} 审批被取消")
             return False, "cancelled"
 
+    def _effective_sid(self, event: AstrMessageEvent) -> str | None:
+        """统一解析当前工具应作用的 session。"""
+        return self.state_mgr.effective_sid(event)
+
+    @staticmethod
+    def _missing_session_text() -> str:
+        return (
+            "当前没有可操作的 session。请先调用 hapi_coding_list_sessions 查看会话，"
+            "再用 hapi_coding_switch_session 切换，或先创建一个新 session。"
+        )
+
     # ──── 查询类工具（无需审批）────
 
     async def tool_get_status(self, event: AstrMessageEvent):
         '''获取当前交互中的 HAPI session 的状态信息。'''
-        sid = self.state_mgr.current_sid(event)
+        sid = self._effective_sid(event)
         if not sid:
-            yield "当前窗口未绑定 session"
+            yield self._missing_session_text()
             return
 
-        session = next((s for s in self.sessions_cache if s.get("id") == sid), None)
-        if not session:
-            yield "Session 不存在"
-            return
-
-        meta = session.get("metadata", {})
-        agent = session.get("agent", "unknown")
-        active = "活跃" if session.get("active") else "非活跃"
-        perm_mode = session.get("permission_mode", "unknown")
-        path = meta.get("path", "unknown")
-
-        info = f"""当前 HAPI Coding Session 状态:
-- Session ID: {sid[:8]}...
-- 路径: {path}
-- Agent: {agent}
-- 状态: {active}
-- 权限模式: {perm_mode}"""
-        yield info
+        try:
+            detail = await session_ops.fetch_session_detail(self.client, sid)
+            yield formatters.format_session_status(detail)
+        except Exception as e:
+            yield f"获取状态失败: {e}"
 
     async def tool_list_sessions(self, event: AstrMessageEvent, window: str = "", path: str = "", agent: str = ""):
         '''列出 HAPI 的可交互 session 列表。
@@ -208,7 +205,7 @@ class LLMIntegration:
             return
 
         # 复用 formatters.format_session_list，但移除 emoji
-        current_sid = self.state_mgr.current_sid(event)
+        current_sid = self._effective_sid(event)
         text = formatters.format_session_list(sessions, current_sid, self.sessions_cache, header_current_window=event.unified_msg_origin)
 
         # 替换 emoji 为文字
@@ -233,9 +230,9 @@ class LLMIntegration:
         Args:
             rounds(number): 查询最近几轮消息（默认 1 轮）
         '''
-        sid = self.state_mgr.current_sid(event)
+        sid = self._effective_sid(event)
         if not sid:
-            yield "当前窗口未绑定 session"
+            yield self._missing_session_text()
             return
 
         try:
@@ -306,9 +303,9 @@ quick_prefix (快捷前缀): {quick_prefix}
         Args:
             message(string): 要发送的消息内容
         '''
-        sid = self.state_mgr.current_sid(event)
+        sid = self._effective_sid(event)
         if not sid:
-            yield "当前窗口未绑定 session"
+            yield self._missing_session_text()
             return
 
         # 请求审批
@@ -462,9 +459,9 @@ quick_prefix (快捷前缀): {quick_prefix}
 
     async def tool_stop_message(self, event: AstrMessageEvent):
         '''停止当前 session 的消息生成。'''
-        sid = self.state_mgr.current_sid(event)
+        sid = self._effective_sid(event)
         if not sid:
-            yield "当前窗口未绑定 session"
+            yield self._missing_session_text()
             return
 
         # 请求审批

--- a/pending_manager.py
+++ b/pending_manager.py
@@ -82,29 +82,60 @@ class PendingManager:
         if not questions:
             return
 
-        async def q_waiter(controller: SessionController, ev: AstrMessageEvent,
-                          sid: str, rid: str, req: dict):
-            user_input = (ev.message_str or "").strip()
-            if not user_input:
-                await ev.send("❌ 输入为空，已取消")
-                return
+        for qi_idx, (sid, rid, req) in enumerate(questions):
+            args = req.get("arguments") or {}
+            question_list = args.get("questions", []) if isinstance(args, dict) else []
+            if not question_list:
+                await event.send(event.plain_result("❌ 当前问题请求缺少题目内容，无法继续回答"))
+                continue
 
-            answers = {opt["label"]: user_input for opt in req.get("options", [])}
-            success = await approval_ops.answer_question(client, sid, rid, answers)
+            answers: dict[str, list[str]] = {}
+
+            for qi, question in enumerate(question_list):
+                opts = question.get("options", [])
+                prompt = approval_ops.build_question_prompt(
+                    questions, qi_idx, qi, question, self.sse_listener.sessions_cache
+                )
+                await event.send(event.plain_result(prompt))
+
+                collected: list[str] = []
+
+                @session_waiter(timeout=120, record_history_chains=False)
+                async def q_waiter(controller: SessionController, ev: AstrMessageEvent,
+                                   _opts=opts, _collected=collected, _state={"other": False}):
+                    reply = (ev.message_str or "").strip()
+                    if not reply:
+                        controller.keep(timeout=120, reset_timeout=True)
+                        return
+
+                    if _state["other"]:
+                        _collected.append(reply)
+                        controller.stop()
+                    elif reply.isdigit() and 1 <= int(reply) <= len(_opts):
+                        _collected.append(_opts[int(reply) - 1]["label"])
+                        controller.stop()
+                    elif reply.isdigit() and int(reply) == len(_opts) + 1:
+                        _state["other"] = True
+                        await ev.send(ev.plain_result("请输入自定义回答:"))
+                        controller.keep(timeout=120, reset_timeout=True)
+                    else:
+                        _collected.append(reply)
+                        controller.stop()
+
+                try:
+                    await q_waiter(event)
+                except TimeoutError:
+                    await event.send(event.plain_result("操作超时，已取消"))
+                    return
+
+                answers[str(qi)] = collected
+
+            success, msg = await approval_ops.answer_question(client, sid, rid, answers)
             if success:
                 self.remove_entry(sid, rid)
-                await ev.send(f"✅ 已提交答案")
+                await event.send(event.plain_result(msg))
             else:
-                await ev.send(f"❌ 提交失败")
-
-        for sid, rid, req in questions:
-            prompt = formatters.format_question_prompt(req)
-            await event.send(prompt)
-            await session_waiter(
-                event,
-                lambda ctrl, ev, s=sid, r=rid, rq=req: q_waiter(ctrl, ev, s, r, rq),
-                timeout=120
-            )
+                await event.send(event.plain_result(f"❌ {msg}"))
 
     # ──── LLM 工具审批（伪装成 HAPI 权限请求）────
 

--- a/session_ops.py
+++ b/session_ops.py
@@ -99,6 +99,12 @@ async def approve_permission(client: AsyncHapiClient, sid: str, rid: str,
         return False, f"批准失败: {resp.status} {body_text[:200]}"
 
 
+async def answer_permission_question(client: AsyncHapiClient, sid: str, rid: str,
+                                     answers: dict) -> tuple[bool, str]:
+    """提交 AskUserQuestion 的回答。"""
+    return await approve_permission(client, sid, rid, answers=answers)
+
+
 async def deny_permission(client: AsyncHapiClient, sid: str, rid: str) -> tuple[bool, str]:
     """拒绝权限请求"""
     resp = await client.post(f"/api/sessions/{sid}/permissions/{rid}/deny", json={})

--- a/sse_listener.py
+++ b/sse_listener.py
@@ -705,7 +705,7 @@ class SSEListener:
         async with self._lock:
             if not self.pending:
                 return
-            pending_snapshot = copy.deepcopy(self.pending)
+            pending_snapshot = self.get_all_pending()
 
         total = sum(len(r) for r in pending_snapshot.values())
         for sid, reqs in pending_snapshot.items():


### PR DESCRIPTION
### Summary
- restore the broken AskUserQuestion approval path used by `/hapi answer`, `/hapi a`, and poke-based approval flows
- align HAPI LLM tools with command-side session resolution so tools can fall back to the effective session instead of only the current window binding
- persist `/hapi output` changes, harden pending-reminder snapshots, and update README to match the current tool count/defaults/visibility

### Verification
- `python -m compileall D:\code\astrbot_plugin_hapi_connector`
- `python -m compileall D:\code\astrbot\data\plugins\astrbot_plugin_hapi_connector`

### Notes
- also synced the updated plugin code into the local AstrBot plugin install for runtime use
