### PR TITLE
fix: robust type checking for dict.get() chains

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -536,7 +536,12 @@ class CommandHandlers:
                 yield event.plain_result(f"{'✓' if ok else '✗'} 已批准: /compact")
             elif self.plugin.pending_mgr.is_llm_tool_request(req):
                 # 从原始 pending 获取 Future
-                original_req = self.sse_listener.pending.get(sid, {}).get(rid, )
+                session_pending = self.sse_listener.pending.get(sid) or {}
+                if not isinstance(session_pending, dict):
+                    session_pending = {}
+                original_req = session_pending.get(rid) or {}
+                if not isinstance(original_req, dict):
+                    original_req = {}
                 future = original_req.get("future")
                 if future and not future.done():
                     future.set_result(True)
@@ -1243,8 +1248,18 @@ class CommandHandlers:
         for sid, umo in self.state_mgr._session_owners.items():
             s = next((s for s in self.sessions_cache if s["id"] == sid), None)
             if s and umo:
-                flavor = s.get("metadata", {}).get("flavor", "?")
-                summary = s.get("metadata", {}).get("summary", ).get("text", "")[:20]
+                metadata = s.get("metadata") or {}
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                flavor = metadata.get("flavor", "?")
+                summary_data = metadata.get("summary") or {}
+                if isinstance(summary_data, dict):
+                    summary_text = summary_data.get("text", "")
+                else:
+                    summary_text = summary_data
+                if summary_text is None:
+                    summary_text = ""
+                summary = str(summary_text)[:20]
                 umo_display = umo[:40] + "..." if len(umo) > 40 else umo
                 lines.append(f"  [{flavor}] {sid[:8]} {summary}\n    → {umo_display}")
                 has_routes = True

--- a/formatters.py
+++ b/formatters.py
@@ -318,7 +318,9 @@ def format_session_list(
     # 按 path 分组但保持原始顺序
     current_path = None
     for local_idx, s in enumerate(sessions, 1):
-        meta = s.get("metadata", )
+        meta = s.get("metadata") or {}
+        if not isinstance(meta, dict):
+            meta = {}
         path = meta.get("path", "(无路径)")
 
         # 当 path 变化时显示分组标题
@@ -331,7 +333,14 @@ def format_session_list(
         sid = s.get("id", "?")
         sid_short = sid[:8]
         display_idx = index_by_sid.get(sid, local_idx)
-        summary = (meta.get("summary") or {}).get("text", "") or "(无标题)"
+        summary_data = meta.get("summary") or {}
+        if isinstance(summary_data, dict):
+            summary_text = summary_data.get("text", "")
+        else:
+            summary_text = summary_data
+        if summary_text is None:
+            summary_text = ""
+        summary = str(summary_text) or "(无标题)"
         flavor = meta.get("flavor", "?")
         model = s.get("modelMode", "default")
         pending = s.get("pendingRequestsCount", 0)

--- a/pending_manager.py
+++ b/pending_manager.py
@@ -52,7 +52,12 @@ class PendingManager:
         for sid, rid, req in regular:
             if self.is_llm_tool_request(req):
                 # 从原始 pending 获取 Future（items 里的 req 可能是副本）
-                original_req = self.sse_listener.pending.get(sid, ).get(rid, {})
+                session_pending = self.sse_listener.pending.get(sid) or {}
+                if not isinstance(session_pending, dict):
+                    session_pending = {}
+                original_req = session_pending.get(rid) or {}
+                if not isinstance(original_req, dict):
+                    original_req = {}
                 future = original_req.get("future")
                 if future:
                     llm_futures.append((sid, rid, future))


### PR DESCRIPTION
## Summary
- 修复 4 处 `.get(key,)` 或 `.get(key, {})` 可能返回 `None` 导致 `AttributeError` 的问题
- 增加显式类型检查，确保链式调用前中间值为字典
- 对 `summary` 文本增加 `None` 归一化，避免显示 `"None"`

## Problem
在权限审批与会话展示相关流程中，存在多处链式 `.get()` 对中间结果未做结构兜底的写法。当键不存在、值为 `None`、或字段结构异常时，会触发：

```
AttributeError: 'NoneType' object has no attribute 'get'
```

影响包括：
- LLM 工具审批 Future 无法正确设置，造成调用阻塞风险
- `/hapi routes` 与 `/hapi list` 等查询命令在异常数据下崩溃

## Changes
| File | Location | Fix |
|------|----------|-----|
| `pending_manager.py` | `approve_items` LLM tool branch | 两步提取 + dict 兜底 |
| `command_handlers.py` | `cmd_allow` LLM tool branch | 两步提取 + dict 兜底 |
| `command_handlers.py` | `cmd_routes` summary display | metadata 兜底 + summary 归一化 |
| `formatters.py` | `format_session_list` | metadata 兜底 + summary 兼容 |

## Verification
- 静态扫描 `.get(key,)` 模式：0 命中
- 语法校验：通过
- 正常数据路径：输出保持一致
- 异常数据路径：由崩溃变为安全降级显示/跳过

🤖 Generated with [Claude Code](https://claude.com/claude-code)