### PR TITLE
feat: support codex reasoning effort on session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ hapi codex    # Open Codex
 
 **使用方式**：在 Astrbot 管理面板开启工具后，直接对话即可，如"切换到1号session"、"创建一个 Claude 会话"。
 
+**Codex 创建补充**：`hapi_coding_create_session` 现在支持可选参数 `model_reasoning_effort`。留空时不会向 HAPI 显式传该字段，Codex 将继承默认设置；具体使用哪套默认设置取决于 Codex 进程实际运行的用户。只有显式填写 `none/minimal/low/medium/high/xhigh` 时才会覆盖默认值。
+
 **推荐配置**：建议至少激活 `hapi_coding_list_commands`。如需覆盖尚未封装的 `/hapi` 子命令，再启用 `hapi_coding_execute_command`；常见操作优先使用结构化工具（如切换、创建、发消息、改配置）。
 
 **审批机制**：操作类工具需管理员审批（支持 `/hapi a` 批准、`/hapi deny` 拒绝、戳一戳快速批准），防止模型误操作。
@@ -194,13 +196,15 @@ hapi codex    # Open Codex
 
 | 指令 | 说明 |
 |------|------|
-| `/hapi create` | 创建新会话（5 步交互向导） |
+| `/hapi create` | 创建新会话（交互向导；Codex 为 6 步，其他为 5 步） |
 | `/hapi abort [序号\|ID前缀]` | 中断会话，默认当前（别名 `stop`） |
 | `/hapi remote` | 切换当前会话到 remote 远程托管模式 |
 | `/hapi archive` | 归档当前会话 |
 | `/hapi rename` | 重命名当前会话 |
 | `/hapi delete` | 删除当前会话 |
 | `/hapi clean [路径前缀]` | 批量清理 inactive session |
+
+> Codex 创建补充：默认会继承 Codex 默认设置中的思考深度；只有你在创建时显式选择 `none/minimal/low/medium/high/xhigh` 时，插件才会覆盖默认值。
 
 #### ✅ 权限审批
 
@@ -299,7 +303,7 @@ astrbot_plugin_hapi_connector/
 ├── approval_ops.py         # 审批业务逻辑
 ├── create_wizard.py        # 创建会话交互式向导
 ├── formatters.py           # 格式化输出工具
-├── constants.py            # 常量定义（权限模式、模型、代理类型）
+├── constants.py            # 常量定义（权限模式、模型、代理类型、Codex 思考深度）
 ├── _conf_schema.json       # 插件配置 schema
 └── metadata.yaml           # 插件元信息
 ```

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -721,6 +721,7 @@ class CommandHandlers:
                     session_type=s["session_type"],
                     yolo=s["yolo"],
                     worktree_name=s["worktree_name"],
+                    model_reasoning_effort=s.get("model_reasoning_effort"),
                 )
                 await self.plugin._refresh_sessions()
                 if ok and new_sid:

--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,18 @@ PERMISSION_MODES = {
 # Claude 可用的模型模式
 MODEL_MODES = ["default", "sonnet", "opus"]
 
+# Codex 可用的思考深度；None 表示继承 Codex 默认设置
+CODEX_REASONING_EFFORT_OPTIONS = [
+    (None, "继承 Codex 默认设置（推荐）"),
+    ("none", "none"),
+    ("minimal", "minimal"),
+    ("low", "low"),
+    ("medium", "medium"),
+    ("high", "high"),
+    ("xhigh", "xhigh"),
+]
+CODEX_REASONING_EFFORT_VALUES = [value for value, _ in CODEX_REASONING_EFFORT_OPTIONS if value]
+
 # 支持的 Agent 类型
 AGENTS = ["claude", "codex", "gemini", "opencode"]
 

--- a/create_wizard.py
+++ b/create_wizard.py
@@ -1,6 +1,6 @@
 """创建 Session 向导状态机：步骤推进、输入校验、提示文本构建"""
 
-from .constants import AGENTS
+from .constants import AGENTS, CODEX_REASONING_EFFORT_OPTIONS, CODEX_REASONING_EFFORT_VALUES
 
 
 class WizardResult:
@@ -18,7 +18,7 @@ class WizardResult:
 
 
 class CreateWizard:
-    """5 步创建 Session 向导，纯状态机，不依赖 AstrBot 事件系统"""
+    """创建 Session 向导，纯状态机，不依赖 AstrBot 事件系统"""
 
     def __init__(self, machines: list, labels: list):
         self.state = {
@@ -31,6 +31,7 @@ class CreateWizard:
             "session_type": "simple",
             "worktree_name": "",
             "agent": None,
+            "model_reasoning_effort": None,
             "yolo": False,
             "recent_paths": [],
         }
@@ -42,6 +43,12 @@ class CreateWizard:
 
     def set_recent_paths(self, paths: list):
         self.state["recent_paths"] = paths
+
+    def _total_steps(self) -> int:
+        return 6 if self.state.get("agent") == "codex" else 5
+
+    def _yolo_step_number(self) -> int:
+        return 6 if self.state.get("agent") == "codex" else 5
 
     def initial_prompt(self) -> WizardResult:
         """返回向导第一条提示（步骤 1 或自动跳到步骤 2）"""
@@ -73,6 +80,25 @@ class CreateWizard:
             lines.append("请输入完整路径")
         return "\n".join(lines)
 
+    def _step5_prompt(self) -> WizardResult:
+        """构建 YOLO 步骤提示"""
+        step_no = self._yolo_step_number()
+        total = self._total_steps()
+        lines = [
+            f"步骤 {step_no}/{total} — 启用 YOLO 模式?",
+            "  [1] 否 — 正常审批流程",
+            "  [2] 是 — 跳过审批和沙箱 (危险)",
+        ]
+        return WizardResult("\n".join(lines))
+
+    def _codex_reasoning_prompt(self) -> WizardResult:
+        """构建 Codex 思考深度提示"""
+        lines = ["代理: codex", "", "步骤 5/6 — 选择 Codex 思考深度:"]
+        for i, (_, label) in enumerate(CODEX_REASONING_EFFORT_OPTIONS, 1):
+            lines.append(f"  [{i}] {label}")
+        lines.append("回复序号选择，或直接输入 none/minimal/low/medium/high/xhigh")
+        return WizardResult("\n".join(lines))
+
     def process(self, raw: str) -> WizardResult:
         """处理用户输入，推进向导状态，返回下一步结果"""
         s = self.state
@@ -88,6 +114,8 @@ class CreateWizard:
             return self._step31(raw)
         elif step == 4:
             return self._step4(raw)
+        elif step == 41:
+            return self._step41(raw)
         elif step == 5:
             return self._step5(raw)
         elif step == 6:
@@ -179,15 +207,28 @@ class CreateWizard:
         else:
             return WizardResult(f"请输入 1~{len(AGENTS)} 的数字或代理名")
 
+        if s["agent"] == "codex":
+            s["step"] = 41
+            return self._codex_reasoning_prompt()
+
         s["step"] = 5
-        lines = [
-            f"代理: {s['agent']}",
-            "",
-            "步骤 5/5 — 启用 YOLO 模式?",
-            "  [1] 否 — 正常审批流程",
-            "  [2] 是 — 跳过审批和沙箱 (危险)",
-        ]
-        return WizardResult("\n".join(lines))
+        s["model_reasoning_effort"] = None
+        return self._step5_prompt()
+
+    def _step41(self, raw: str) -> WizardResult:
+        """步骤 4.1: 选择 Codex 思考深度"""
+        s = self.state
+        if raw.isdigit() and 1 <= int(raw) <= len(CODEX_REASONING_EFFORT_OPTIONS):
+            s["model_reasoning_effort"] = CODEX_REASONING_EFFORT_OPTIONS[int(raw) - 1][0]
+        else:
+            normalized = raw.strip().lower()
+            if normalized in CODEX_REASONING_EFFORT_VALUES:
+                s["model_reasoning_effort"] = normalized
+            else:
+                return WizardResult("请输入有效序号，或直接输入 none/minimal/low/medium/high/xhigh")
+
+        s["step"] = 5
+        return self._step5_prompt()
 
     def _step5(self, raw: str) -> WizardResult:
         """步骤 5: YOLO 模式"""
@@ -206,8 +247,11 @@ class CreateWizard:
             f"  目录:     {s['directory']}",
             f"  类型:     {s['session_type']}",
             f"  代理:     {s['agent']}",
-            f"  YOLO:     {'是' if s['yolo'] else '否'}",
         ]
+        if s["agent"] == "codex":
+            reasoning_text = s["model_reasoning_effort"] or "继承 Codex 默认设置"
+            lines.append(f"  思考深度: {reasoning_text}")
+        lines.append(f"  YOLO:     {'是' if s['yolo'] else '否'}")
         if s["worktree_name"]:
             lines.append(f"  工作树名: {s['worktree_name']}")
         if s["agent"] == "codex" and s["yolo"]:

--- a/llm_integration.py
+++ b/llm_integration.py
@@ -352,7 +352,8 @@ quick_prefix (快捷前缀): {quick_prefix}
                 yield str(result)
 
     async def tool_create_session(self, event: AstrMessageEvent, directory: str, agent: str,
-                                   machine_id: str = "", session_type: str = "simple", yolo: bool = False):
+                                   machine_id: str = "", session_type: str = "simple", yolo: bool = False,
+                                   model_reasoning_effort: str = ""):
         '''创建新的 coding session。
 
         Args:
@@ -361,6 +362,7 @@ quick_prefix (快捷前缀): {quick_prefix}
             machine_id(string): 机器 ID（可选，管理多机器时必填）
             session_type(string): session 类型（simple/worktree，默认 simple）
             yolo(boolean): 是否自动批准所有权限（默认 false）
+            model_reasoning_effort(string): 仅 Codex 可选；留空表示继承 Codex 默认设置，可选 none/minimal/low/medium/high/xhigh
         '''
         # 获取机器列表
         try:
@@ -371,6 +373,12 @@ quick_prefix (快捷前缀): {quick_prefix}
 
         if not machines:
             yield "没有在线的机器"
+            return
+
+        agent = (agent or "").strip().lower()
+        from .constants import AGENTS
+        if agent not in AGENTS:
+            yield f"不支持的 agent: {agent}，可选: {', '.join(AGENTS)}"
             return
 
         # 处理 machine_id
@@ -388,10 +396,27 @@ quick_prefix (快捷前缀): {quick_prefix}
                 yield "\n".join(lines)
                 return
 
+        normalized_effort = (model_reasoning_effort or "").strip().lower()
+        if agent == "codex":
+            from .constants import CODEX_REASONING_EFFORT_VALUES
+            inherit_aliases = {"", "inherit", "default", "auto"}
+            if normalized_effort in inherit_aliases:
+                normalized_effort = ""
+            elif normalized_effort not in CODEX_REASONING_EFFORT_VALUES:
+                yield "Codex 的 model_reasoning_effort 只能是留空(继承默认配置)或 none/minimal/low/medium/high/xhigh"
+                return
+        elif normalized_effort:
+            yield "只有 Codex 支持 model_reasoning_effort；其他代理请留空"
+            return
+
+        approval_payload = {"machine_id": machine_id, "directory": directory,
+                            "agent": agent, "session_type": session_type, "yolo": yolo}
+        if agent == "codex":
+            approval_payload["model_reasoning_effort"] = normalized_effort or "inherit"
+
         # 请求审批
         approved, reason = await self._require_approval("hapi_coding_create_session",
-                                           {"machine_id": machine_id, "directory": directory,
-                                            "agent": agent, "session_type": session_type, "yolo": yolo}, event)
+                                           approval_payload, event)
         if not approved:
             if reason == "timeout":
                 yield "操作超时：60秒内未收到用户审批。请提醒用户使用 /hapi a 批准或 /hapi deny 拒绝。"
@@ -402,7 +427,7 @@ quick_prefix (快捷前缀): {quick_prefix}
             return
 
         # 执行创建
-        ok, msg, sid = await session_ops.spawn_session(self.client, machine_id, directory, agent, session_type, yolo)
+        ok, msg, sid = await session_ops.spawn_session(self.client, machine_id, directory, agent, session_type, yolo, model_reasoning_effort=normalized_effort or None)
         if ok and sid:
             await self.state_mgr.capture_window(sid, event.unified_msg_origin, agent)
             yield f"✅ 已创建 session: {sid[:8]}"

--- a/main.py
+++ b/main.py
@@ -200,7 +200,8 @@ class HapiConnectorPlugin(Star):
 
     @filter.llm_tool(name="hapi_coding_create_session")
     async def tool_create_session(self, event: AstrMessageEvent, directory: str, agent: str,
-                                   machine_id: str = "", session_type: str = "simple", yolo: bool = False):
+                                   machine_id: str = "", session_type: str = "simple", yolo: bool = False,
+                                   model_reasoning_effort: str = ""):
         '''创建新的 coding session。创建成功后会自动切换到新session，无需手动调用switch_session。
 
         Args:
@@ -209,8 +210,10 @@ class HapiConnectorPlugin(Star):
             machine_id(string): 机器ID，可选，管理多机器时必填
             session_type(string): session类型，simple或worktree，默认simple
             yolo(boolean): 是否自动批准所有权限，默认false
+            model_reasoning_effort(string): 仅 Codex 可选；留空表示继承 Codex 默认设置，可选 none/minimal/low/medium/high/xhigh
         '''
-        async for result in self.llm_integration.tool_create_session(event, directory, agent, machine_id, session_type, yolo):
+        async for result in self.llm_integration.tool_create_session(
+                event, directory, agent, machine_id, session_type, yolo, model_reasoning_effort):
             yield result
 
     @filter.llm_tool(name="hapi_coding_change_config")

--- a/session_ops.py
+++ b/session_ops.py
@@ -200,7 +200,8 @@ async def fetch_recent_paths(client: AsyncHapiClient) -> list[str]:
 
 async def spawn_session(client: AsyncHapiClient, machine_id: str,
                         directory: str, agent: str, session_type: str = "simple",
-                        yolo: bool = False, worktree_name: str = "") -> tuple[bool, str, str | None]:
+                        yolo: bool = False, worktree_name: str = "",
+                        model_reasoning_effort: str | None = None) -> tuple[bool, str, str | None]:
     """创建新 session，返回 (成功, 消息, session_id 或 None)"""
     body = {
         "directory": directory,
@@ -210,6 +211,8 @@ async def spawn_session(client: AsyncHapiClient, machine_id: str,
     }
     if worktree_name:
         body["worktreeName"] = worktree_name
+    if model_reasoning_effort:
+        body["modelReasoningEffort"] = model_reasoning_effort
 
     resp = await client.post(f"/api/machines/{machine_id}/spawn", json=body)
     if resp.status != 200:


### PR DESCRIPTION
## 变更简介

本 PR 优化了 `astrbot_plugin_hapi_connector` 在创建 **Codex session** 时的思考深度行为。

现在创建 Codex 会话时支持两种模式：

1. **默认继承**
   - 插件不会向 HAPI 显式传 `modelReasoningEffort`
   - 由 Codex 自行继承默认设置
   - 具体使用哪套默认设置，取决于 Codex 进程实际运行的用户

2. **显式覆盖**
   - 当用户明确选择思考深度时，插件会向 HAPI 传入对应值
   - 支持：
     - `none`
     - `minimal`
     - `low`
     - `medium`
     - `high`
     - `xhigh`

---

## 具体改动

- 在常量定义中新增 Codex 思考深度选项
- 扩展 `/hapi create` 交互向导
  - 创建 Codex 会话时新增“思考深度”步骤
  - 默认选项为“继承 Codex 默认设置（推荐）”
- 扩展 session 创建请求体
  - 只有在用户显式选择时才发送 `modelReasoningEffort`
- 扩展 `hapi_coding_create_session` 工具
  - 新增可选参数 `model_reasoning_effort`
  - 留空表示继承 Codex 默认设置
- 更新 README 文档说明

---

## 行为说明

### Codex
- 如果用户选择“继承默认设置”，插件不会发送 `modelReasoningEffort`
- 如果用户显式选择某个值，则插件会发送对应的 `modelReasoningEffort`

### 其他代理
以下代理行为保持不变，不受本次改动影响：

- `claude`
- `gemini`
- `opencode`

---

## 修改原因

HAPI / Codex 在未显式指定 `modelReasoningEffort` 时，本身就可以沿用 Codex 默认设置。  
插件侧补上这层适配后，默认体验会更自然：

- 普通用户无需额外理解 reasoning effort
- 有明确需求的用户仍可手动覆盖
- 行为更符合 Codex 原生配置习惯

---

## 验证情况

### 自动验证

已完成以下验证：

- Python 语法检查
  - `python3 -m compileall .`
- 向导流程验证
  - 创建 Codex 时会出现新增的思考深度步骤
  - 选择“继承默认设置”时，确认摘要正确
  - 选择 `high` 时，确认摘要正确
- 请求体验证
  - 默认继承模式下，不发送 `modelReasoningEffort`
  - 显式指定 `high` 时，发送 `modelReasoningEffort: high`

---

## 验证记录

### 验证环境
- 宿主机：`自部署 Linux 服务器`
- AstrBot 插件线上目录：`/opt/1panel/apps/astrbot/astrbot/data/plugins/astrbot_plugin_hapi_connector`
- 工作仓库：`/home/lzt/workspace/astrbot_plugin_hapi_connector`
- HAPI 版本：`0.16.4`

### 部署方式
已将工作仓库同步到线上插件目录，并重启 `astrbot`：

```bash
cp -a /opt/1panel/apps/astrbot/astrbot/data/plugins/astrbot_plugin_hapi_connector \
  /opt/1panel/apps/astrbot/astrbot/data/plugins/astrbot_plugin_hapi_connector.bak.<timestamp>

rsync -av --delete --exclude .git --exclude __pycache__ --exclude docs/superpowers \
  /home/lzt/workspace/astrbot_plugin_hapi_connector/ \
  /opt/1panel/apps/astrbot/astrbot/data/plugins/astrbot_plugin_hapi_connector/

docker restart astrbot
```

### 静态验证

已通过 Python 语法编译检查：

```bash
python3 -m py_compile constants.py create_wizard.py session_ops.py \
  llm_integration.py command_handlers.py main.py
```

结果：

- 通过，无语法错误

---

## 备注

- 本 PR 仅调整 **创建 Codex 会话时** 的默认行为
- **不包含**运行中动态修改 Codex 思考深度的能力
- **未修改** HAPI 上游，仅为插件侧适配