### PR TITLE
feat: add /hapi resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ hapi codex    # Open Codex
 | `/hapi abort [序号\|ID前缀]` | 中断会话，默认当前（别名 `stop`） |
 | `/hapi remote` | 切换当前会话到 remote 远程托管模式 |
 | `/hapi archive` | 归档当前会话 |
+| `/hapi resume [序号\|ID前缀]` | 恢复被 archive 的 inactive session |
 | `/hapi rename` | 重命名当前会话 |
 | `/hapi delete` | 删除当前会话 |
 | `/hapi clean [路径前缀]` | 批量清理 inactive session |

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -62,6 +62,7 @@ class CommandHandlers:
             "abort": (self.cmd_abort, True),
             "stop": (self.cmd_abort, True),
             "archive": (self.cmd_archive, False),
+            "resume": (self.cmd_resume, True),
             "rename": (self.cmd_rename, False),
             "delete": (self.cmd_delete, False),
             "clean": (self.cmd_clean, True),
@@ -833,6 +834,49 @@ class CommandHandlers:
         matches = [s for s in self.sessions_cache if s.get("id", "").startswith(target)]
         return matches[0]["id"] if len(matches) == 1 else None
 
+    # ── resume ──
+
+    async def cmd_resume(self, event: AstrMessageEvent, target: str = ""):
+        """恢复 inactive session: /hapi resume [序号|ID前缀]"""
+        await self.state_mgr.set_user_state(event)
+        await self.plugin._refresh_sessions()
+
+        if not target:
+            sid = self.state_mgr.effective_sid(event)
+            if not sid:
+                yield event.plain_result("请先用 /hapi sw <序号> 选择一个 session，或使用 /hapi resume <序号>")
+                return
+        else:
+            sid = None
+            if target.isdigit():
+                idx = int(target)
+                if 1 <= idx <= len(self.sessions_cache):
+                    sid = self.sessions_cache[idx - 1]["id"]
+            if sid is None:
+                matches = [s for s in self.sessions_cache
+                           if s.get("id", "").startswith(target)]
+                if len(matches) == 1:
+                    sid = matches[0]["id"]
+                elif len(matches) > 1:
+                    labels = [f"  {s['id'][:8]}..." for s in matches]
+                    yield event.plain_result(
+                        f"匹配到 {len(matches)} 个 session，请更精确:\n"
+                        + "\n".join(labels))
+                    return
+            if sid is None:
+                yield event.plain_result("未找到匹配的 session")
+                return
+
+        ok, msg, resumed_sid = await session_ops.resume_session(self.client, sid)
+        if ok and resumed_sid:
+            await self.plugin._refresh_sessions()
+            resumed = next((s for s in self.sessions_cache if s.get("id") == resumed_sid), None)
+            flavor = (resumed or {}).get("metadata", {}).get("flavor") or self.state_mgr.effective_flavor(event) or "claude"
+            await self.state_mgr.capture_window(resumed_sid, event.unified_msg_origin, flavor)
+            if resumed_sid != sid:
+                msg += f"\n已自动切换到恢复后的 session [{flavor}] {resumed_sid[:8]}..."
+        yield event.plain_result(msg)
+
     # ── rename ──
 
     async def cmd_rename(self, event: AstrMessageEvent, target: str = ""):
@@ -1306,4 +1350,3 @@ class CommandHandlers:
         await self.plugin._refresh_sessions()
 
         yield event.plain_result("✓ 已重置所有状态\n捕获关系和窗口状态已清空，默认窗口和 flavor 默认路由已保留")
-

--- a/formatters.py
+++ b/formatters.py
@@ -741,6 +741,7 @@ KNOWN_HAPI_SUBCOMMANDS = {
     "create",
     "abort", "stop",
     "archive",
+    "resume",
     "rename",
     "delete",
     "clean",
@@ -830,6 +831,13 @@ HELP_COMMANDS = [
         "summary": "归档当前 session",
         "example": None,
         "home": False,
+    },
+    {
+        "topic": "session",
+        "usage": "/hapi resume [序号|ID前缀]",
+        "summary": "恢复被 archive 的 inactive session",
+        "example": "/hapi resume 1",
+        "home": True,
     },
     {
         "topic": "session",

--- a/session_ops.py
+++ b/session_ops.py
@@ -153,6 +153,20 @@ async def archive_session(client: AsyncHapiClient, sid: str) -> tuple[bool, str]
         return False, f"归档失败: {resp.status} {body[:200]}"
 
 
+async def resume_session(client: AsyncHapiClient, sid: str) -> tuple[bool, str, str | None]:
+    """恢复 inactive session，返回 (成功, 描述, 恢复后的 session_id 或 None)"""
+    resp = await client.post(f"/api/sessions/{sid}/resume", json={})
+    if resp.ok:
+        data = await resp.json()
+        resp.release()
+        resumed_sid = data.get("sessionId") or sid
+        return True, f"已恢复 [{resumed_sid[:8]}]", resumed_sid
+    else:
+        body = await resp.text()
+        resp.release()
+        return False, f"恢复失败: {resp.status} {body[:200]}", None
+
+
 async def rename_session(client: AsyncHapiClient, sid: str, new_name: str) -> tuple[bool, str]:
     """重命名 session"""
     resp = await client.patch(f"/api/sessions/{sid}", json={"name": new_name})


### PR DESCRIPTION
 ## 变更说明

  本 PR 为 `astrbot_plugin_hapi_connector` 增加了 `/hapi resume` 能力，用于恢复被 archive 已归档的 inactive session。

  本次改动包括：

  - 新增 `/hapi resume [序号|ID前缀]` 指令
  - 在 `session_ops.py` 中封装 HAPI 的 `POST /api/sessions/:id/resume`
  - 恢复成功后，自动切换到恢复后的新 session
  - 更新帮助文案与 README
  - 将 `resume` 的位置调整到 `archive` 之后，表达上更符合实际使用顺序

  ## 改动文件

  - `session_ops.py`
  - `command_handlers.py`
  - `formatters.py`
  - `README.md`

  ## 设计说明

  `/hapi resume` 的行为与上游 HAPI 语义保持一致：

  - 目标 session 必须是 inactive
  - 恢复成功后，HAPI 可能返回一个新的 session id
  - 插件侧会自动切换当前窗口到恢复后的 session

  ## 验证情况

  ### 1. 静态验证

  已执行：

  ```bash
  python3 -m py_compile session_ops.py command_handlers.py formatters.py
  ```

  结果：通过。

  ### 2. HAPI live API 验证

  已在真实 HAPI 0.16.4 环境中验证：

  - POST /api/sessions/:id/resume 接口可用
  - 对 Codex session，恢复成功依赖上游 metadata 中已存在 codexSessionId
  - 新建但尚未完成线程初始化的 Codex session，直接 resume 可能返回：

  `Resume session ID unavailable`
  `code: resume_unavailable`

  这属于上游 HAPI 的前置条件，不是本插件新增逻辑导致。

  ### 3. AstrBot 实际聊天窗口端到端验证

  已在真实 QQ 会话中完成完整验证，实际过程如下：

  USER: /hapi ls

  BOT: 当前窗口 ID: AstrBot:FriendMessage:9AFF94680BBD02BDD1A1A9F74B0A5C27

  共 5 个 Session:

  📁 /home/lzt/workspace (5)
  1 | 🏷️0f9915b1
  🟢运行中 | 🤖codex:default | <<当前
  [5 | 🏷️c4cb3fb0] 实现 /hapi resume 功能
  🟢运行中 | 🤖codex:default

  💡 切换会话：/hapi sw <序号或ID前缀>

  ---

  USER: /hapi archive 0f9915b1

  BOT: 确认归档 session [0f9915b1]?
  回复 y 确认

  ---

  USER: y

  BOT: 归档成功 [0f9915b1]

  ---

  USER: /hapi ls

  BOT: 当前窗口 ID: AstrBot:FriendMessage:9AFF94680BBD02BDD1A1A9F74B0A5C27

  共 5 个 Session:

  📁 /home/lzt/workspace (5)
  [4 | 🏷️c4cb3fb0] 实现 /hapi resume 功能
  🟢运行中 | 🤖codex:default
  6 | 🏷️0f9915b1
  ⚪已关闭 | 🤖codex:default | <<当前

  💡 切换会话：/hapi sw <序号或ID前缀>

  ---

  USER: /hapi resume 6

  BOT: 💬 (无标题)
  📂 /home/lzt/workspace
  🤖 codex | 🏷️ bfb9065f
  [Message]: 我先按 `using-superpowers` 技能检查本轮流程。

  你好呀！有什么我可以帮你的？

  已恢复 [bfb9065f]
  已自动切换到恢复后的 session [codex] bfb9065f...

  ---

  USER: /hapi ls

  BOT: 当前窗口 ID: AstrBot:FriendMessage:9AFF94680BBD02BDD1A1A9F74B0A5C27

  共 5 个 Session:

  📁 /home/lzt/workspace (5)
  1 | 🏷️bfb9065f
  🟢运行中 | 🤖codex:default | <<当前
  [5 | 🏷️c4cb3fb0] 实现 /hapi resume 功能
  🟢运行中 | 🤖codex:default

  💡 切换会话：/hapi sw <序号或ID前缀>

  ### 验证结论：

  - /hapi archive 可正常将目标 session 归档为 inactive
  - /hapi resume 可正常恢复该 session
  - 恢复后会生成新的 session id
  - 插件会自动切换当前窗口到恢复后的新 session
  - /hapi ls 中的当前会话指向也会同步更新

  ## 注意事项

  对于 Codex session：

  - 只有在上游 HAPI 已记录 codexSessionId 后，resume 才能成功
  - 因此，刚创建但尚未真正完成初始化的 Codex session，不保证可以立即 resume，需要至少发回一次消息。

  本 PR 的目标是：

  - 正确适配 HAPI 现有的 resume 能力
  - 在 AstrBot 侧提供完整、可用且符合上游语义的恢复流程

 --- 

 -  `formatters.py` 的 diff 里面显示的某些删除其实并没有变化，可能有点显示错误
 -  后端 hapi 对 resume 的支持较早，可以不用特意强调版本