### PR TITLE
功能：优化 Codex 会话标题兼容性/feat: improve Codex session title compatibility

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -211,7 +211,7 @@ class CommandHandlers:
         flavor = chosen.get("metadata", {}).get("flavor", "claude")
         umo = event.unified_msg_origin
         await self.state_mgr.capture_window(sid, umo, flavor)
-        summary = chosen.get("metadata", {}).get("summary", {}).get("text", "(无标题)")
+        summary = formatters.get_session_title(chosen)
         yield event.plain_result(f"已切换到 [{flavor}] {sid[:8]}... {summary}")
 
     # ── s (status) ──
@@ -1476,14 +1476,7 @@ class CommandHandlers:
                 if not isinstance(metadata, dict):
                     metadata = {}
                 flavor = metadata.get("flavor", "?")
-                summary_data = metadata.get("summary") or {}
-                if isinstance(summary_data, dict):
-                    summary_text = summary_data.get("text", "")
-                else:
-                    summary_text = summary_data
-                if summary_text is None:
-                    summary_text = ""
-                summary = str(summary_text)[:20]
+                summary = formatters.get_session_title(s)[:20]
                 umo_display = umo[:40] + "..." if len(umo) > 40 else umo
                 lines.append(f"  [{flavor}] {sid[:8]} {summary}\n    → {umo_display}")
                 has_routes = True

--- a/formatters.py
+++ b/formatters.py
@@ -229,7 +229,7 @@ def session_label_short(sid: str, sessions_cache: list[dict]) -> str:
 
     meta = session.get("metadata", {})
     flavor = meta.get("flavor", "?")
-    summary = (meta.get("summary") or {}).get("text", "")
+    summary = get_session_title(session)
     path = meta.get("path", "")
 
     title = summary or "(无标题)"
@@ -271,7 +271,7 @@ def format_bind_status(sessions: list[dict], session_owners: dict[str, str], win
 
         sid = s.get("id", "?")
         sid_short = sid[:8]
-        summary = (meta.get("summary") or {}).get("text", "") or "(无标题)"
+        summary = get_session_title(s)
         flavor = meta.get("flavor", "?")
         model = s.get("modelMode", "default")
         pending = s.get("pendingRequestsCount", 0)
@@ -345,14 +345,7 @@ def format_session_list(
         sid = s.get("id", "?")
         sid_short = sid[:8]
         display_idx = index_by_sid.get(sid, local_idx)
-        summary_data = meta.get("summary") or {}
-        if isinstance(summary_data, dict):
-            summary_text = summary_data.get("text", "")
-        else:
-            summary_text = summary_data
-        if summary_text is None:
-            summary_text = ""
-        summary = str(summary_text) or "(无标题)"
+        summary = get_session_title(s)
         flavor = meta.get("flavor", "?")
         model = s.get("modelMode", "default")
         pending = s.get("pendingRequestsCount", 0)
@@ -380,6 +373,41 @@ def format_session_list(
     return "\n".join(lines)
 
 
+def get_session_title(session: dict) -> str:
+    """
+    获取 Session 标题（兼容新版 Codex / HAPI / 旧版）
+    """
+
+    meta = session.get("metadata") or {}
+
+    # summary 兼容 dict / string
+    summary = meta.get("summary")
+    if isinstance(summary, dict):
+        summary = summary.get("text")
+    elif summary is not None:
+        summary = str(summary)
+
+    candidates = (
+        session.get("thread_name"),      # 新版 Codex
+        meta.get("thread_name"),
+
+        meta.get("name"),                # HAPI rename
+        session.get("name"),
+
+        session.get("title"),
+
+        summary,                         # 旧版 Codex
+
+        meta.get("path"),                # 最后兜底
+    )
+
+    for value in candidates:
+        if value:
+            return str(value)
+
+    return "(无标题)"
+
+
 def format_session_status(s: dict) -> str:
     """格式化单个 session 状态"""
     meta = s.get("metadata", {})
@@ -391,7 +419,7 @@ def format_session_status(s: dict) -> str:
     perm = s.get("permissionMode", "default")
     model = s.get("modelMode", "default")
     collab = s.get("collaborationMode", "default")
-    summary = (meta.get("summary") or {}).get("text", "(无标题)")
+    summary = get_session_title(s)
 
     lines = [
         f"Session:  {sid[:8]}...",


### PR DESCRIPTION
- 新增 get_session_title()，统一会话标题获取逻辑。
- 支持新版 Codex 使用的 thread_name 字段。
- 支持 HAPI rename 写入的 metadata.name 字段。
- 保留对旧版 summary.text 的兼容。
- 替换 formatters 和 command_handlers 中重复的标题解析逻辑。
English
- Add get_session_title() helper to centralize session title resolution.
- Support thread_name used by newer Codex versions.
- Support metadata.name set by HAPI rename.
- Preserve compatibility with legacy summary.text.
- Replace duplicated title parsing logic in formatters and command handlers.