### PR TITLE
fix: 修复工具调用输出格式，支持 cmd 字段并添加代码框包裹/fix: improve tool call output format with cmd field support and code block wrapping

### DIFF
--- a/render/formatters.py
+++ b/render/formatters.py
@@ -285,9 +285,13 @@ def _fmt_tool_call(block: dict, max_len: int) -> str:
         ):
             path = inp.get("file_path") or inp.get("path") or inp.get("filePath")
             return f"🛠️ {name}: {_short_path(str(path))}"
-        cmd = inp.get("command", "")
+        cmd = inp.get("command") or inp.get("cmd") or ""
         if cmd:
-            return f"🛠️ {name}: {cmd[:max_len]}"
+            cmd_str = str(cmd)
+            if len(cmd_str) > max_len:
+                cmd_str = cmd_str[:max_len] + "..."
+            tool_icon = "🛠️"
+            return tool_icon + " " + name + ":\n```\n" + cmd_str + "\n```"
         args_str = json.dumps(inp, ensure_ascii=False)[:max_len]
         return f"🛠️ {name}: {args_str}"
     return f"🛠️ {name}"


### PR DESCRIPTION
fix: 修复工具调用输出格式，支持 cmd 字段并添加代码框包裹

- 修复 exec_command 等工具调用显示不全的问题（只识别 command 字段，未识别 cmd 字段）
- 工具调用命令输出改为代码框包裹，提升可读性

fix: improve tool call output format with cmd field support and code block wrapping

- Fix tool calls like exec_command not displaying command properly (only checked 'command' field, missed 'cmd' field)
- Wrap tool call commands in markdown code blocks for better readability