### PR TITLE
feat(hapi): 优先使用 event.send 发送通知，保留 Markdown 渲染/feat(hapi): prefer ev…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,8 @@ dev-docs/
 
 # Git
 .gitignore
+
+# Font files
+assets/fonts/*.ttf
+assets/fonts/*.otf
+assets/fonts/*.ttc

--- a/core/notification_manager.py
+++ b/core/notification_manager.py
@@ -76,9 +76,16 @@ class NotificationManager:
                 chunks = self.split_message(text) if len(text) > 4200 else [text]
 
                 for chunk in chunks:
+                    cached_event = self._event_cache.get(umo)
                     try:
-                        chain = MessageChain().message(chunk)
-                        await self.context.send_message(umo, chain)
+                        if cached_event:
+                            result = cached_event.plain_result(chunk)
+                            logger.warning("send (umo=%s)   ", umo[:20])
+                            await cached_event.send(result)
+                        else:
+                            logger.warning("send_message (umo=%s)", umo[:20])
+                            chain = MessageChain().message(chunk)
+                            await self.context.send_message(umo, chain)
                     except Exception:
                         cached_event = self._event_cache.get(umo)
                         if cached_event:

--- a/pages/console/api.js
+++ b/pages/console/api.js
@@ -95,6 +95,7 @@ export function createApi(bridge) {
     /** 推送卡片：能力元数据 / 实卡预览 / 勾选安装字体或依赖 */
     renderMeta: () => get("render/meta"),
     renderPreview: (body) => post("render/preview", body || {}),
+    renderTextTest: (body) => post("render/text-test", body || {}),
     /** body: { ids: ["font_noto_sc","dep_pillow"], force?: bool } */
     renderInstall: (body) => post("render/install", body || {}),
   };

--- a/pages/console/pages/interact.js
+++ b/pages/console/pages/interact.js
@@ -8,6 +8,7 @@ import { renderTopConn, renderAlert, toast, paintSaveStatus } from "../ui.js?v=3
 import { refresh } from "../data.js?v=3.0.1";
 import { isLive, getApi } from "../live.js?v=3.0.1";
 import { helpTopics, helpCommands } from "./help.js?v=3.0.1";
+import { renderMarkdown } from "../md.js?v=3.0.1";
 
 
 /** 当前生效的完整 CSS 文本（默认或已保存自定义） */
@@ -359,12 +360,95 @@ function normalizeRenderMode(m) {
   return String(m || "text").toLowerCase() === "card" ? "card" : "text";
 }
 
+const DEFAULT_TEXT_PREVIEW_MARKDOWN = `# Markdown 测试
+
+这是普通文字，下面用于检查纯文本发送效果。
+
+**粗体文字**  *斜体文字*  ~~删除线~~
+
+- 第一项
+- 第二项
+- 第三项
+
+> 这是一段引用内容。
+
+\`\`\`python
+print("Hello from HAPI Connector")
+\`\`\`
+
+[示例链接](https://example.com)`;
+
+function textWindowOptionsHtml() {
+  const options = Array.isArray(state.data?.window_options)
+    ? state.data.window_options
+    : [];
+  const rows = ['<option value="">请选择窗口</option>'];
+  for (const item of options) {
+    if (!item || !item.umo) continue;
+    rows.push(
+      `<option value="${attr(item.umo)}">${esc(item.title || item.name || item.umo)}</option>`,
+    );
+  }
+  return rows.join("");
+}
+
+function textSessionOptionsHtml() {
+  const sessions = Array.isArray(state.data?.sessions) ? state.data.sessions : [];
+  const rows = ['<option value="">请选择 HAPI Session</option>'];
+  for (const item of sessions) {
+    if (!item || !item.id) continue;
+    const route = item.effective_umo ? ` · 路由 ${item.effective_umo}` : " · 暂无路由";
+    rows.push(
+      `<option value="${attr(item.id)}">${esc(`[${item.flavor || "unknown"}] ${item.title || item.id_short || item.id}${route}`)}</option>`,
+    );
+  }
+  return rows.join("");
+}
+
+const TEXT_TEST_MODE_HINTS = {
+  direct_window: "直接使用 context.send_message() 主动发到窗口；用于和命令回复链路对照。普通 QQ 通常会原样显示 Markdown 标记。",
+  bound_plain: "调用正式 NotificationManager，按 Session 绑定、Agent 默认或全局默认路由推送纯文本。",
+  sse_message: "模拟 HAPI SSE 自动拉取到 Agent 消息后的完整呈现链路，并遵循当前 render_mode / render_kinds 设置。",
+  command_reply: "与 /hapi msg 最接近：使用目标窗口最近缓存的 AstrMessageEvent，通过 plain_result() 返回。需先在该窗口发过消息。",
+};
+
+function syncTextTestControls() {
+  const mode = $("#ix-text-test-mode")?.value || "command_reply";
+  const windowField = $("#ix-text-window-field");
+  const sessionField = $("#ix-text-session-field");
+  const hint = $("#ix-text-mode-hint");
+  const needsWindow = mode === "command_reply" || mode === "direct_window";
+  if (windowField) windowField.hidden = !needsWindow;
+  if (sessionField) sessionField.hidden = needsWindow;
+  if (hint) hint.textContent = TEXT_TEST_MODE_HINTS[mode] || "";
+}
+
+function paintTextMarkdownPreview() {
+  const input = $("#ix-text-markdown");
+  const preview = $("#ix-text-markdown-preview");
+  const raw = $("#ix-text-raw-preview");
+  if (!input) return;
+  const text = String(input.value || "");
+  if (preview) {
+    preview.innerHTML = text.trim()
+      ? renderMarkdown(text)
+      : '<p class="field-help">输入 Markdown 后将在这里显示解析预览。</p>';
+  }
+  if (raw) raw.textContent = text;
+}
+
 function syncCardPanelVisibility(mode) {
   mode = normalizeRenderMode(mode);
   const panel = $("#ix-card-panel");
   const preview = $("#ix-preview-pane");
+  const textPreview = $("#ix-text-preview-pane");
+  const textInner = $("#ix-text-preview-inner");
+  const cardInner = $("#ix-card-preview-inner");
   if (panel) panel.hidden = mode !== "card";
-  if (preview) preview.hidden = mode !== "card";
+  if (preview) preview.hidden = false; // 右栏始终显示
+  if (textPreview) textPreview.hidden = mode !== "text";
+  if (textInner) textInner.hidden = mode !== "text";
+  if (cardInner) cardInner.hidden = mode !== "card";
   // enum-card 高亮
   $$('#ix-rmode-cards input[name="ix-rmode"]').forEach((inp) => {
     const card = inp.closest(".enum-card");
@@ -1501,24 +1585,83 @@ function renderInteract() {
           </div>
 
           </div><!-- /ix-card-panel -->
-        </div>
+
+          <div id="ix-text-preview-pane" ${rs.render_mode === "text" ? "" : "hidden"}>
+            <div class="field-label-row" style="margin-bottom:8px">
+              <div>
+                <div class="field-label">纯文本 Markdown 测试</div>
+                <p class="field-help" style="margin:4px 0 0">发送到聊天窗口时仍按纯文本发送原始 Markdown。</p>
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field-label">Markdown 内容</div>
+              <textarea id="ix-text-markdown" class="ctrl ix-text-markdown-input" rows="14" spellcheck="false" placeholder="输入要测试的 Markdown…">${esc(DEFAULT_TEXT_PREVIEW_MARKDOWN)}</textarea>
+            </div>
+
+            <div class="field">
+              <div class="field-label">消息输出链路</div>
+              <select id="ix-text-test-mode" class="ctrl" style="width:100%">
+                <option value="direct_window">② 直接主动发送到窗口（对照）</option>
+                <option value="bound_plain">③ 按绑定路由推送纯文本</option>
+                <option value="sse_message">④ SSE Agent 自动消息呈现</option>
+                <option value="command_reply">① /hapi msg 命令回复（plain_result）</option>
+              </select>
+              <p class="field-help" id="ix-text-mode-hint"></p>
+            </div>
+
+            <div class="field" id="ix-text-window-field">
+              <div class="field-label">目标窗口</div>
+              <select id="ix-text-target-window" class="ctrl" style="width:100%">
+                ${textWindowOptionsHtml()}
+              </select>
+            </div>
+
+            <div class="field" id="ix-text-session-field" hidden>
+              <div class="field-label">目标 HAPI Session</div>
+              <select id="ix-text-target-session" class="ctrl" style="width:100%">
+                ${textSessionOptionsHtml()}
+              </select>
+              <p class="field-help">实际窗口由该 Session 当前绑定、Agent 默认路由或全局默认窗口决定。</p>
+            </div>
+          </div>
+        </div><!-- /render-form -->
 
         <div class="render-preview-pane" id="ix-preview-pane" ${rs.render_mode === "card" ? "" : "hidden"}>
-          <div class="field-label-row" style="margin-bottom:8px">
-            <div class="field-label">预览</div>
-            <select id="ix-sample" class="ctrl" style="max-width:160px">
-              ${Object.keys(RENDER_KIND_LABELS)
-                .map((k) => `<option value="${k}">${esc(RENDER_KIND_LABELS[k])}</option>`)
-                .join("")}
-            </select>
+
+          <!-- 纯文本模式预览 -->
+          <div id="ix-text-preview-inner" ${rs.render_mode === "text" ? "" : "hidden"}>
+            <div class="field-label" style="margin-bottom:8px">Markdown 解析预览</div>
+            <div id="ix-text-markdown-preview" class="md-body render-dom-host text-markdown-preview"></div>
+            <details class="text-raw-details" style="margin-top:12px">
+              <summary>查看窗口实际接收的原始文本</summary>
+              <pre id="ix-text-raw-preview" class="render-fallback text-raw-preview"></pre>
+            </details>
+            <div class="render-actions" style="margin-top:16px">
+              <button type="button" class="btn" id="ix-text-refresh-preview">仅刷新预览</button>
+              <button type="button" class="btn btn-primary" id="ix-text-send">执行消息链路测试</button>
+            </div>
+            <div id="ix-text-send-status" class="field-help" style="margin-top:8px"></div>
           </div>
-          <p class="field-help">左侧 DOM 示意结构；点「生成实图」走服务端 Pillow（读自定义 CSS 变量），与聊天发出一致。</p>
-          <div id="ix-dom-preview" class="render-dom-host"></div>
-          <div class="render-actions" style="margin-top:12px">
-            <button type="button" class="btn btn-primary" id="ix-gen-card">生成实图预览</button>
-          </div>
-          <div id="ix-real-meta" class="field-help" style="margin-top:8px"></div>
-          <div id="ix-real-preview" class="render-real-host"></div>
+
+          <!-- 卡片模式预览 -->
+          <div id="ix-card-preview-inner" ${rs.render_mode === "card" ? "" : "hidden"}>
+            <div class="field-label-row" style="margin-bottom:8px">
+              <div class="field-label">预览</div>
+              <select id="ix-sample" class="ctrl" style="max-width:160px">
+                ${Object.keys(RENDER_KIND_LABELS)
+                  .map((k) => `<option value="${k}">${esc(RENDER_KIND_LABELS[k])}</option>`)
+                  .join("")}
+              </select>
+            </div>
+            <p class="field-help">左侧 DOM 示意结构；点「生成实图」走服务端 Pillow（读自定义 CSS 变量），与聊天发出一致。</p>
+            <div id="ix-dom-preview" class="render-dom-host"></div>
+            <div class="render-actions" style="margin-top:12px">
+              <button type="button" class="btn btn-primary" id="ix-gen-card">生成实图预览</button>
+            </div>
+            <div id="ix-real-meta" class="field-help" style="margin-top:8px"></div>
+            <div id="ix-real-preview" class="render-real-host"></div>
+          </div><!-- /ix-card-preview-inner -->
         </div>
       </div>
 
@@ -1724,6 +1867,77 @@ function renderInteract() {
       await saveRenderSettings();
     });
 
+  const textMarkdownInput = $("#ix-text-markdown");
+  if (textMarkdownInput) textMarkdownInput.oninput = paintTextMarkdownPreview;
+  const textModeSelect = $("#ix-text-test-mode");
+  if (textModeSelect) textModeSelect.onchange = syncTextTestControls;
+  syncTextTestControls();
+
+  $("#ix-text-refresh-preview") &&
+    ($("#ix-text-refresh-preview").onclick = () => {
+      paintTextMarkdownPreview();
+      const status = $("#ix-text-send-status");
+      if (status) status.textContent = "预览已更新，没有发送消息。";
+    });
+
+  $("#ix-text-send") &&
+    ($("#ix-text-send").onclick = async () => {
+      paintTextMarkdownPreview();
+      const button = $("#ix-text-send");
+      const status = $("#ix-text-send-status");
+      const mode = $("#ix-text-test-mode")?.value || "command_reply";
+      const target = $("#ix-text-target-window")?.value || "";
+      const sid = $("#ix-text-target-session")?.value || "";
+      const text = $("#ix-text-markdown")?.value || "";
+      const needsWindow = mode === "command_reply" || mode === "direct_window";
+
+      if (!text.trim()) {
+        if (status) status.textContent = "请输入测试内容。";
+        toast("测试内容不能为空");
+        return;
+      }
+      if (needsWindow && !target) {
+        if (status) status.textContent = "请选择目标窗口。";
+        toast("请选择目标窗口");
+        return;
+      }
+      if (!needsWindow && !sid) {
+        if (status) status.textContent = "请选择目标 HAPI Session。";
+        toast("请选择目标 Session");
+        return;
+      }
+      if (!isLive() || !getApi()) {
+        if (status) status.textContent = "本地静态预览模式无法发送，请在 AstrBot 插件面板中操作。";
+        return;
+      }
+
+      const oldText = button?.textContent || "执行消息链路测试";
+      try {
+        if (button) {
+          button.disabled = true;
+          button.classList.add("is-busy");
+          button.textContent = "测试中…";
+        }
+        if (status) status.textContent = "正在执行所选消息输出链路…";
+        const res = await getApi().renderTextTest({ mode, umo: target, sid, text });
+        if (!res?.ok) throw new Error(res?.error || res?.message || "发送失败");
+        if (status) {
+          status.textContent = `${res.mode_label || mode} · 成功 · ${res.chars || text.length} 字符 · 目标 ${res.target || "已按路由选择"}`;
+        }
+        toast("消息链路测试已执行");
+      } catch (e) {
+        const message = e?.message || String(e);
+        if (status) status.textContent = "测试失败：" + message;
+        toast("测试失败：" + message);
+      } finally {
+        if (button) {
+          button.disabled = false;
+          button.classList.remove("is-busy");
+          button.textContent = oldText;
+        }
+      }
+    });
+
   $("#ix-gen-card") &&
     ($("#ix-gen-card").onclick = async () => {
       const kind = $("#ix-sample")?.value || "session_list";
@@ -1773,6 +1987,7 @@ function renderInteract() {
     });
 
   paintDomCardPreview();
+  paintTextMarkdownPreview();
   // 以当前表单为基线：未改动时状态区留空
   captureInteractBaseline();
   paintQuickSaveStatus("");

--- a/pages/console/style.css
+++ b/pages/console/style.css
@@ -4362,3 +4362,58 @@ input[type="range"] {
   line-height: 1.55;
 }
 .font-scan-locs code { font-size: 11px; }
+
+
+/* 纯文本模式 Markdown 测试区 */
+.ix-text-markdown-input {
+  width: 100%;
+  min-height: 250px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  line-height: 1.55;
+}
+.text-markdown-preview {
+  min-height: 260px;
+  padding: 20px;
+  overflow: auto;
+  line-height: 1.7;
+  word-break: break-word;
+}
+
+/* 纯文本 Markdown 测试 - 左右两栏 */
+.text-test-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  align-items: start;
+}
+.text-test-left {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.text-test-right {
+  display: flex;
+  flex-direction: column;
+}
+@media (max-width: 900px) {
+  .text-test-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.text-markdown-preview .md-h:first-child,
+.text-markdown-preview .md-p:first-child {
+  margin-top: 0;
+}
+.text-raw-details summary {
+  cursor: pointer;
+  color: var(--muted, #6b7280);
+}
+.text-raw-preview {
+  margin-top: 8px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 360px;
+  overflow: auto;
+}

--- a/webui/web_api.py
+++ b/webui/web_api.py
@@ -134,6 +134,7 @@ def register_pages(plugin) -> None:
         (f"{prefix}/hub/launch", api.hub_launch, ["GET"], "WebUI HAPI Web launch URL"),
         (f"{prefix}/render/meta", api.render_meta, ["GET"], "WebUI render meta"),
         (f"{prefix}/render/preview", api.render_preview, ["POST"], "WebUI card preview"),
+        (f"{prefix}/render/text-test", api.render_text_test, ["POST"], "WebUI text test send"),
         (f"{prefix}/render/install", api.render_install, ["POST"], "WebUI install font/deps"),
     ]
     for route, handler, methods, desc in routes:
@@ -207,6 +208,411 @@ class WebApi:
         except Exception as e:
             logger.exception("WebUI render_meta failed")
             return error_response(f"render/meta 失败: {type(e).__name__}: {e}", status_code=500)
+
+    async def render_text_test(self):
+        """从 WebUI 测试不同消息输出链路。
+
+        mode:
+        - direct_window:
+            使用 context.send_message 主动发送到指定窗口
+        - bound_plain:
+            使用 NotificationManager，按照 Session 绑定路由推送纯文本
+        - sse_message:
+            模拟 SSE Agent 消息呈现链路，遵循 render_mode/render_kinds
+        - command_reply:
+            模拟 /hapi msg，使用缓存事件调用 cmd_msg
+        """
+        from astrbot.api.event import MessageChain
+        from astrbot.api.web import error_response, json_response, request
+
+        allowed_modes = {
+            "command_reply",
+            "direct_window",
+            "bound_plain",
+            "sse_message",
+        }
+
+        mode_labels = {
+            "direct_window": "直接主动发送链路",
+            "bound_plain": "绑定路由纯文本通知链路",
+            "sse_message": "SSE Agent 消息呈现链路",
+            "command_reply": "/hapi msg 命令回复链路",
+        }
+
+        try:
+            # ------------------------------------------------------------
+            # 1. 读取请求参数
+            # ------------------------------------------------------------
+            payload = await request.json(default={})
+
+            if not isinstance(payload, dict):
+                return error_response(
+                    "请求体必须是 JSON 对象",
+                    status_code=400,
+                )
+
+            mode = str(
+                payload.get("mode") or "command_reply"
+            ).strip().lower()
+
+            text = str(payload.get("text") or "")
+            umo = str(payload.get("umo") or "").strip()
+            sid = str(payload.get("sid") or "").strip()
+            rounds = str(payload.get("rounds") or "1").strip()
+
+            if mode not in allowed_modes:
+                return error_response(
+                    f"未知发送方式: {mode}",
+                    status_code=400,
+                )
+
+            # command_reply 实际调用 /hapi msg，不直接使用 text。
+            if mode != "command_reply":
+                if not text.strip():
+                    return error_response(
+                        "测试内容不能为空",
+                        status_code=400,
+                    )
+
+                if len(text) > 20000:
+                    return error_response(
+                        "测试内容过长，最多 20000 个字符",
+                        status_code=400,
+                    )
+
+            # ------------------------------------------------------------
+            # 2. 获取窗口、Session 和插件组件
+            # ------------------------------------------------------------
+            snap = build_sessions_snapshot(self.plugin)
+
+            window_options = snap.get("window_options") or []
+            session_options = snap.get("sessions") or []
+
+            allowed_umos = {
+                str(item.get("umo") or "").strip()
+                for item in window_options
+                if isinstance(item, dict)
+                and str(item.get("umo") or "").strip()
+            }
+
+            allowed_sids = {
+                str(item.get("id") or "").strip()
+                for item in session_options
+                if isinstance(item, dict)
+                and str(item.get("id") or "").strip()
+            }
+
+            notification_mgr = getattr(
+                self.plugin,
+                "notification_mgr",
+                None,
+            )
+
+            state_mgr = getattr(
+                self.plugin,
+                "state_mgr",
+                None,
+            )
+
+            sessions_cache = list(
+                getattr(self.plugin, "sessions_cache", None) or []
+            )
+
+            # ------------------------------------------------------------
+            # 3. 校验目标窗口或 Session
+            # ------------------------------------------------------------
+            if mode in {"command_reply", "direct_window"}:
+                if not umo:
+                    return error_response(
+                        "该发送方式需要选择目标窗口",
+                        status_code=400,
+                    )
+
+                if umo not in allowed_umos:
+                    return error_response(
+                        "目标窗口不在当前可用窗口列表中，请刷新页面后重试",
+                        status_code=400,
+                    )
+
+            if mode in {"bound_plain", "sse_message"}:
+                if not sid:
+                    return error_response(
+                        "该发送方式需要选择 HAPI Session",
+                        status_code=400,
+                    )
+
+                if sid not in allowed_sids:
+                    return error_response(
+                        "目标 Session 不在当前会话列表中，请刷新页面后重试",
+                        status_code=400,
+                    )
+
+                if state_mgr is None:
+                    return error_response(
+                        "state_mgr 尚未初始化",
+                        status_code=503,
+                    )
+
+            # ------------------------------------------------------------
+            # 4. 准备文本分片
+            # ------------------------------------------------------------
+            if mode == "command_reply":
+                # command_reply 不直接发送 text。
+                chunks = []
+
+            elif notification_mgr is not None:
+                chunks = notification_mgr.split_message(
+                    text,
+                    max_len=4200,
+                )
+
+            else:
+                chunks = [
+                    text[index:index + 4200]
+                    for index in range(0, len(text), 4200)
+                ]
+
+            sent = 0
+            target_desc = umo or sid
+
+            # ------------------------------------------------------------
+            # 5. 直接主动发送到指定窗口
+            # ------------------------------------------------------------
+            if mode == "direct_window":
+                context = getattr(
+                    self.plugin,
+                    "context",
+                    None,
+                )
+
+                if context is None:
+                    return error_response(
+                        "插件 context 尚未初始化",
+                        status_code=503,
+                    )
+
+                for chunk in chunks:
+                    chain = MessageChain().message(chunk)
+                    await context.send_message(umo, chain)
+                    sent += 1
+
+            # ------------------------------------------------------------
+            # 6. 按 Session 绑定路由推送纯文本
+            # ------------------------------------------------------------
+            elif mode == "bound_plain":
+                if notification_mgr is None:
+                    return error_response(
+                        "notification_mgr 尚未初始化",
+                        status_code=503,
+                    )
+
+                targets = state_mgr.select_notification_targets(
+                    sid,
+                    sessions_cache,
+                )
+
+                if not targets:
+                    return error_response(
+                        "该 Session 当前没有绑定窗口、"
+                        "Agent 默认路由或全局默认窗口",
+                        status_code=409,
+                    )
+
+                await notification_mgr.push_notification(
+                    text,
+                    sid,
+                    sessions_cache,
+                )
+
+                sent = len(chunks)
+                target_desc = ", ".join(
+                    map(str, targets)
+                )
+
+            # ------------------------------------------------------------
+            # 7. 模拟 SSE Agent 消息呈现链路
+            # ------------------------------------------------------------
+            elif mode == "sse_message":
+                listener = getattr(
+                    self.plugin,
+                    "sse_listener",
+                    None,
+                )
+
+                push_card = (
+                    getattr(listener, "_push_message_card", None)
+                    if listener is not None
+                    else None
+                )
+
+                if not callable(push_card):
+                    return error_response(
+                        "SSE 消息呈现链路尚未初始化",
+                        status_code=503,
+                    )
+
+                session = next(
+                    (
+                        item
+                        for item in sessions_cache
+                        if isinstance(item, dict)
+                        and str(item.get("id") or "") == sid
+                    ),
+                    None,
+                )
+
+                label = formatters.session_label_short(
+                    sid,
+                    sessions_cache,
+                )
+
+                title = (
+                    formatters.get_session_title(session)
+                    if session
+                    else "WebUI 消息测试"
+                )
+
+                targets = state_mgr.select_notification_targets(
+                    sid,
+                    sessions_cache,
+                )
+
+                if not targets:
+                    return error_response(
+                        "该 Session 当前没有可用推送路由",
+                        status_code=409,
+                    )
+
+                await push_card(
+                    session_id=sid,
+                    label=label,
+                    body=text,
+                    fallback_text=f"{label}\n{text}",
+                    title=title,
+                    footer="WebUI 测试",
+                )
+
+                sent = 1
+                target_desc = ", ".join(
+                    map(str, targets)
+                )
+
+            # ------------------------------------------------------------
+            # 8. 模拟 /hapi msg 命令回复链路
+            # ------------------------------------------------------------
+            elif mode == "command_reply":
+                if notification_mgr is None:
+                    return error_response(
+                        "notification_mgr 尚未初始化",
+                        status_code=503,
+                    )
+
+                event_cache = getattr(
+                    notification_mgr,
+                    "_event_cache",
+                    None,
+                )
+
+                if not isinstance(event_cache, dict):
+                    logger.warning(
+                        "notification_mgr._event_cache 类型异常: %s",
+                        type(event_cache).__name__,
+                    )
+
+                    return error_response(
+                        "事件缓存尚未初始化",
+                        status_code=503,
+                    )
+
+                cached_event = event_cache.get(umo)
+
+                if cached_event is None:
+                    logger.info(
+                        "WebUI command_reply 无缓存事件: "
+                        "umo=%r cache_keys=%r",
+                        umo,
+                        list(event_cache.keys()),
+                    )
+
+                    return error_response(
+                        "该窗口暂无缓存事件。请先在目标窗口执行一次 "
+                        "/hapi msg 或触发一次快捷前缀命令，再重试。",
+                        status_code=409,
+                    )
+
+                cmd_handlers = getattr(
+                    self.plugin,
+                    "cmd_handlers",
+                    None,
+                )
+
+                cmd_msg = (
+                    getattr(cmd_handlers, "cmd_msg", None)
+                    if cmd_handlers is not None
+                    else None
+                )
+
+                if not callable(cmd_msg):
+                    return error_response(
+                        "cmd_msg 命令处理器尚未初始化",
+                        status_code=503,
+                    )
+
+                logger.info(
+                    "开始模拟 /hapi msg: "
+                    "umo=%r rounds=%r event_type=%s",
+                    umo,
+                    rounds,
+                    type(cached_event).__name__,
+                )
+
+                # cmd_msg 内部使用了 yield，因此它是异步生成器。
+                async for result in cmd_msg(
+                    cached_event,
+                    rounds,
+                ):
+                    if result is None:
+                        continue
+
+                    await cached_event.send(result)
+                    sent += 1
+
+            # ------------------------------------------------------------
+            # 9. 返回测试结果
+            # ------------------------------------------------------------
+            logger.info(
+                "WebUI 消息测试成功: "
+                "mode=%s target=%s text_chars=%d sent=%d",
+                mode,
+                str(target_desc)[:120],
+                len(text),
+                sent,
+            )
+
+            return json_response({
+                "ok": True,
+                "mode": mode,
+                "mode_label": mode_labels.get(mode, mode),
+                "target": target_desc,
+                "chars": len(text),
+                "chunks": sent,
+                "message": "测试消息已提交",
+            })
+
+        except Exception as exc:
+            logger.exception(
+                "WebUI render_text_test failed: "
+                "mode=%r umo=%r sid=%r",
+                locals().get("mode"),
+                locals().get("umo"),
+                locals().get("sid"),
+            )
+
+            return error_response(
+                "render/text-test 失败: "
+                f"{type(exc).__name__}: {exc}",
+                status_code=500,
+            )
 
     async def render_install(self):
         """WebUI 手动安装：字体下载到 assets/fonts/，依赖 pip install Pillow。


### PR DESCRIPTION
# HAPI 主动通知发送逻辑优化

## 背景

HAPI 插件原本已经维护窗口对应的 Event 缓存：

```python
self.notification_mgr._event_cache[
    event.unified_msg_origin
] = event
```

插件在部分消息处理入口中，会将当前窗口最近一次收到的 `AstrMessageEvent` 保存到 `_event_cache`。

本次修改没有新增 Event 缓存，也没有调整 Event 的缓存时机。

本次只修改了主动通知的发送逻辑。

---

# 原有机制

## 1. Event 缓存

HAPI 插件原本已经存在：

```python
_event_cache
```

缓存结构大致为：

```python
dict[str, AstrMessageEvent]
```

其中：

```text
Key   = event.unified_msg_origin
Value = 当前窗口最近一次收到的 AstrMessageEvent
```

该缓存用于保存窗口最近一次真实收到的事件对象。

本次修改未调整这部分逻辑。

---

## 2. Event 缓存更新

HAPI 插件原本已经会在部分消息入口中更新 Event，例如：

```python
self.notification_mgr._event_cache[
    event.unified_msg_origin
] = event
```

目前可见的更新位置包括：

* `quick_prefix_handler`
* `keyword_map_handler`

例如，用户通过快捷前缀发送消息：

```text
> hello
```

消息进入 `quick_prefix_handler` 后，当前窗口对应的 Event 会被写入 `_event_cache`。

关键词映射命令命中时，`keyword_map_handler` 也会更新当前窗口的 Event。

这些均为原有逻辑，本次修改未新增或调整。

---

# 本次修改内容

## 3. 优化主动通知发送逻辑

原来的主动通知统一使用：

```python
await self.context.send_message(
    unified_msg_origin,
    chain,
)
```

实际测试发现：

* `context.send_message()` 可以正常发送消息；
* 但发送 Markdown 内容时，部分平台会直接显示 Markdown 原文；
* 使用当前窗口的 `event.send(chain)` 时，Markdown 可以正常显示为格式化后的内容。

因此，本次将主动通知发送逻辑修改为：

```text
优先查找当前窗口缓存的 Event
                │
                ├── 存在 Event
                │       ↓
                │  event.send(chain)
                │
                └── 不存在 Event
                        ↓
           context.send_message(umo, chain)
```

即：

```python
event = self._event_cache.get(unified_msg_origin)

if event is not None:
    await event.send(chain)
else:
    await self.context.send_message(
        unified_msg_origin,
        chain,
    )
```

修改后的逻辑会优先复用窗口最近一次真实收到的 Event。

当没有可用 Event 时，仍然回退到原有的 `context.send_message()`，保证通知不会因为缺少 Event 而发送失败。

---

## 4. WebUI 新增消息发送测试

为了方便验证主动通知发送效果，本次同时在 HAPI Connector WebUI 中增加了消息发送测试功能。

当前测试功能主要用于开发阶段验证不同发送方式的实际效果，包括：

* 主动通知发送是否成功；
* Markdown 在不同发送路径下的显示效果；
* `event.send()` 与 `context.send_message()` 的行为差异；
* 后续发送逻辑调整后的快速回归测试。

目前 WebUI 已提供简单的文本发送入口，可直接向指定窗口发送测试消息，而无需通过实际通知流程进行验证。

该功能主要用于开发和调试，因此当前实现仍属于辅助测试功能，并非完整的通知管理界面。

后续可根据需要继续扩展，例如：

* Markdown 内容测试；
* MessageChain 可视化构造；
* 不同发送模式切换；
* 发送结果及日志展示；
* 更多消息类型（图片、文件等）的测试支持。

---


# 修改后的行为

## 当前窗口存在缓存 Event

以下情况通常会存在缓存 Event：

* 当前 AstrBot 运行周期内，该窗口发送过消息；
* 用户通过 `>` 快捷前缀与 HAPI 交互过；
* 用户触发过会更新 `_event_cache` 的关键词映射命令。

此时主动通知使用：

```python
await event.send(chain)
```

效果：

* 消息能够正常发送；
* Markdown 可以正常显示为格式化后的内容。

例如：

```markdown
# 执行完成

- 状态：成功
- 会话：123
- 耗时：10 秒
```

会按照 Markdown 对应的显示效果发送，而不是直接显示全部 Markdown 标记。

---

## 当前窗口不存在缓存 Event

以下情况通常不存在缓存 Event：

* AstrBot 或插件刚刚重启；
* 当前窗口在本次运行周期内还没有发送过消息；
* 当前窗口虽然已经绑定，但还没有产生可缓存的真实 Event；
* 该窗口的消息没有经过现有的 Event 缓存入口。

此时主动通知回退到：

```python
await self.context.send_message(
    unified_msg_origin,
    chain,
)
```

效果：

* 消息仍然能够正常发送；
* Markdown 可能按照原始文本显示。

例如可能显示为：

```text
# 执行完成

- 状态：成功
- 会话：123
- 耗时：10 秒
```

---

# Event 缓存的生命周期

`AstrMessageEvent` 是收到真实消息时，由 AstrBot 创建的运行时对象。

`_event_cache` 属于内存缓存，不会在插件重启后自动恢复。

因此，即使窗口已经完成绑定：

```text
已绑定窗口
```

也不等于：

```text
当前运行周期内已经存在可用 Event
```

插件或 AstrBot 重启后，原有 Event 对象会失效或丢失。

必须等到窗口再次产生一条被现有逻辑缓存的真实消息后，主动通知才会重新使用：

```python
event.send(chain)
```

在此之前，通知仍然会使用：

```python
context.send_message()
```

---

# 兼容性处理

本次修改保留了原有发送方式作为回退逻辑。

因此不会出现以下情况：

```text
没有 Event
→ 无法发送通知
```

实际行为是：

```text
有 Event
→ 使用 event.send()
→ 优先获得 Markdown 显示效果
```

```text
没有 Event
→ 使用 context.send_message()
→ 保证通知仍然可以送达
```

本次修改只改变了主动通知发送时选择发送方式的逻辑，不影响：

* 窗口绑定逻辑；
* 会话管理逻辑；
* Event 缓存结构；
* Event 缓存更新入口；
* 原有通知目标识别逻辑；
* 原有无 Event 时的基础发送能力。

---

# 已知限制

当前 Markdown 显示效果依赖缓存中的真实 Event。

因此存在以下限制：

1. 插件或 AstrBot 重启后，Event 缓存会清空。
2. 已绑定但尚未产生新消息的窗口，没有可用 Event。
3. 没有 Event 时，仍会通过 `context.send_message()` 发送 Markdown 原文。
4. 当前修改并未解决 `context.send_message()` 本身不处理 Markdown 的问题。
5. 当前修改没有新增统一的 Event 捕获或缓存处理逻辑。

---

# 后续可选优化

以下内容不属于本次修改，仅作为后续方向。

## 统一更新已绑定窗口的 Event

目前 Event 缓存由原有的部分消息入口进行更新。

后续可以考虑增加统一的消息监听入口，在已绑定窗口收到任意真实消息时刷新 `_event_cache`。

这样可以减少对特定命令入口的依赖。

---

## 统一主动发送与 Event 发送的 Markdown 处理链

后续可以继续研究 AstrBot 中：

```python
event.send()
```

与：

```python
context.send_message()
```

在发送流程上的差异。

如果能够让 `context.send_message()` 复用相同的 Markdown 转换或消息处理逻辑，就可以不再依赖 Event 缓存。

---

# 总结

本次修改只优化了主动通知的发送选择逻辑。

原有逻辑：

```python
context.send_message()
```

修改后：

```text
存在缓存 Event
→ event.send()
```

```text
不存在缓存 Event
→ context.send_message()
```

最终达到以下效果：

* 有 Event 时优先保留 Markdown 显示效果；
* 没有 Event 时仍然保证消息可以发送；
* 不修改原有 Event 缓存及缓存更新机制；
* 不影响现有窗口绑定和通知路由逻辑。

ps:ai总结的。XD,需求是我想出来的。WebUI的测试部分可能不太完善，做了的部分都进行了测试。这样就不用每次通过实际发消息给hapi等返回才能看对消息内容的修改是否正确了。