### PR TITLE
fix: text 模式下 generated-image 图片退化成 hapi-genimg 文本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+## v3.2.5
+
+1. **修复纯文本模式下 agent 图片（generated-image）退化成 Markdown 文本的问题**  
+   `output_level=simple` / `render_mode=text` 时，HAPI 的 `generated-image` 消息块虽然已被解析并缓存为本地图片，但纯文本回退文案（`fallback_text`）仍保留原始 `hapi-genimg://` 标记，导致 QQ 等平台只显示 `![alt](hapi-genimg://...)` 文本而不发图。现在推送前对回退文案同样执行 `resolve_hapi_genimg_markers`，text 模式下图片会以真实图片随正文一起发送。
+
 ## v3.2.4
 
 1. **新增 `/hapi sync`：将 Codex Session 同步到 HAPI**  

--- a/core/sse_listener.py
+++ b/core/sse_listener.py
@@ -984,6 +984,17 @@ class SSEListener:
             except Exception as e:
                 logger.warning("resolve genimg markers failed: %s", e)
                 body_resolved = body
+            # 纯文本回退同样解析 hapi-genimg://，否则 text 模式图片退化成
+            # ![alt](hapi-genimg://id) 文本（上游 v3.2.4 未覆盖此路径）
+            fallback_resolved = fallback_text
+            try:
+                if client and fallback_text and "hapi-genimg://" in fallback_text:
+                    fallback_resolved = await output_present.resolve_hapi_genimg_markers(
+                        fallback_text, client=client, session_id=session_id
+                    )
+            except Exception as e:
+                logger.warning("resolve genimg markers in fallback failed: %s", e)
+                fallback_resolved = fallback_text
             payload = output_present.build_message_payload(
                 label=label,
                 body=body_resolved,
@@ -1001,7 +1012,7 @@ class SSEListener:
                 notif,
                 "message",
                 payload,
-                fallback_text,
+                fallback_resolved,
                 session_id,
                 self.sessions_cache,
             )


### PR DESCRIPTION
## 问题

`output_level=simple` + `render_mode=text` 时，HAPI 的 `generated-image` 消息块在 QQ/微信等聊天平台显示为 `![alt](hapi-genimg://<id>)` 纯文本，图片不会真正发送。

## 原因

`core/sse_listener.py` 的 `_push_message_card()` 只把 `resolve_hapi_genimg_markers()` 解析后的本地路径放进卡片 payload（`body`），而纯文本回退使用的 `fallback_text` 仍保留原始 `hapi-genimg://` 标记。

`present_push()` 在 text 模式下走 `_push_plain_with_images()` → `extract_local_images_for_plain()`，该函数只识别本地绝对路径 / `file://`，不识别 `hapi-genimg://`，于是图片没有进入待发送列表，整段 Markdown 文本被原样发出。

## 修复

对 `fallback_text` 同样执行 `resolve_hapi_genimg_markers()`，再传给 `present_push()`。text 模式下图片会下载为本地临时文件，并随正文以真实图片发送（先发正文占位「见下方图片」，再按顺序发图）。

## 验证

- 环境：AstrBot 4.26.7 + HAPI 0.23.4，`output_level=simple`、`render_mode=text`，QQ 官方平台
- 修复前：QQ 显示 `Message]: ![title](hapi-genimg://<id>)`
- 修复后：QQ 收到「见下方图片」正文 + 真实图片
- 日志确认：`genimg cached ... bytes=26104 path=/tmp/hapi_genimg_*.jpg` 出现两次（body 与 fallback 各一次），图片推送无报错

关联：v3.2.3 曾声明「纯文本模式也支持发送图片」，此路径是该能力的遗漏修复。