### PR TITLE
fix: 修正 SSE 事件中权限请求字段层级读取

### DIFF
--- a/core/sse_listener.py
+++ b/core/sse_listener.py
@@ -306,7 +306,10 @@ class SSEListener:
         # 处理权限请求
         new_requests: list[tuple[str, dict]] = []
         if agent_state:
-            requests_data = agent_state.get("requests") or {}
+            # SSE 事件中 agentState 结构为 {version, value:{requests, ...}}，
+            # 兼容部分场景直接扁平放 requests
+            agent_state_value = agent_state.get("value") or {}
+            requests_data = agent_state_value.get("requests") or agent_state.get("requests") or {}
             async with self._lock:
                 old_reqs = self.pending.get(sid, {})
                 new_requests = [
@@ -1077,6 +1080,8 @@ class SSEListener:
                 continue
             try:
                 detail = await session_ops.fetch_session_detail(self.client, sid)
+                # fetch_session_detail 已解包 {session:{...}}，返回扁平 session 对象；
+                # agentState 为 {controlledByUser, startingMode, requests, completedRequests} 扁平结构
                 agent_state = detail.get("agentState") or {}
                 requests_data = agent_state.get("requests") or {}
                 if requests_data:


### PR DESCRIPTION
## 修复内容
修复 `core/sse_listener.py` 中权限请求字段读取的层级错误。

hapi 0.27.2 的 SSE `session-updated` 事件中 `agentState` 结构为 `{version, value:{requests, completedRequests}}`，权限请求在 `agentState.value.requests`；原代码读顶层 `agent_state.get("requests")` 恒为空，导致收不到授权申请。

改为兼容读取 `value.requests`（优先）与扁平 `requests`。

## 修改文件
- `core/sse_listener.py`: 第 ~309 行 `_handle` 主循环中的权限请求提取

## 验证
在本机 + 服务器实测：修复后 AstrBot 能正常收到并推送权限申请卡片。

## 关联
Closes #32