### PR TITLE
fix(render): preserve missing glyphs in image cards

### DIFF
--- a/render/card_render.py
+++ b/render/card_render.py
@@ -2428,14 +2428,17 @@ def _load_font(size: int, mono: bool, style: CardStyle, *, bold: bool = False):
 
 
 def _text_size(draw, text: str, font, *, stroke_width: int = 0) -> tuple[int, int]:
-    kwargs: dict[str, Any] = {}
-    if stroke_width:
-        kwargs["stroke_width"] = stroke_width
-    try:
-        bbox = draw.textbbox((0, 0), text or " ", font=font, **kwargs)
-    except TypeError:
-        bbox = draw.textbbox((0, 0), text or " ", font=font)
-    return bbox[2] - bbox[0], bbox[3] - bbox[1]
+    width = 0
+    height = 0
+    kwargs: dict[str, Any] = {"stroke_width": stroke_width} if stroke_width else {}
+    for run, run_font in font_manager.get_font_runs(text or " ", font):
+        try:
+            bbox = draw.textbbox((0, 0), run, font=run_font, **kwargs)
+        except TypeError:
+            bbox = draw.textbbox((0, 0), run, font=run_font)
+        width += bbox[2] - bbox[0]
+        height = max(height, bbox[3] - bbox[1])
+    return width, height
 
 
 def _draw_text(
@@ -2450,20 +2453,18 @@ def _draw_text(
     """绘制文字；bold_stroke 时用 1px stroke 合成加粗（无粗体字文件时的兜底）。"""
     if not text:
         return
-    if bold_stroke:
+    current_x = xy[0]
+    for run, run_font in font_manager.get_font_runs(text, font):
+        kwargs: dict[str, Any] = {"font": run_font, "fill": fill}
+        if bold_stroke:
+            kwargs.update(stroke_width=1, stroke_fill=fill)
         try:
-            draw.text(
-                xy,
-                text,
-                font=font,
-                fill=fill,
-                stroke_width=1,
-                stroke_fill=fill,
-            )
-            return
+            draw.text((current_x, xy[1]), run, **kwargs)
         except TypeError:
-            pass
-    draw.text(xy, text, font=font, fill=fill)
+            kwargs.pop("stroke_width", None)
+            kwargs.pop("stroke_fill", None)
+            draw.text((current_x, xy[1]), run, **kwargs)
+        current_x += _text_size(draw, run, run_font, stroke_width=1 if bold_stroke else 0)[0]
 
 
 # 行内：图片 / 链接 / `code` / **bold** / __bold__ / *em*（不含嵌套）
@@ -2889,11 +2890,11 @@ def _draw_status_png(
     )
 
     y = pad
-    draw.text((pad, y), title, font=font_title, fill=fg)
+    _draw_text(draw, (pad, y), title, font_title, fg)
     y += _text_size(draw, title, font_title)[1] + 8
     if subtitle:
         for line in _wrap_text(draw, subtitle, font_sub, content_w):
-            draw.text((pad, y), line, font=font_sub, fill=sub_fg)
+            _draw_text(draw, (pad, y), line, font_sub, sub_fg)
             y += _text_size(draw, line or " ", font_sub)[1] + 3
         y += 6
 
@@ -2911,11 +2912,12 @@ def _draw_status_png(
         cr = badge_dot
         cy = y + badge_h // 2
         draw.ellipse((pad + badge_pad_x - 6, cy - cr, pad + badge_pad_x - 6 + cr * 2, cy + cr), fill=sc)
-        draw.text(
+        _draw_text(
+            draw,
             (pad + badge_pad_x - 6 + cr * 2 + 8, y + (badge_h - bh) // 2),
             status,
-            font=font_badge,
-            fill=sc,
+            font_badge,
+            sc,
         )
         y += badge_h + 14
     else:
@@ -2939,17 +2941,18 @@ def _draw_status_png(
         )
         # 左标签
         lw, lh = _text_size(draw, label, font_label)
-        draw.text(
+        _draw_text(
+            draw,
             (pad + 14, y + (h - lh) // 2),
             label,
-            font=font_label,
-            fill=sub_fg,
+            font_label,
+            sub_fg,
         )
         # 右值（可多行）
         vx = pad + label_w + 8
         vy = y + 8
         for line in val_lines:
-            draw.text((vx, vy), line, font=font_value, fill=fg)
+            _draw_text(draw, (vx, vy), line, font_value, fg)
             vy += _text_size(draw, line or " ", font_value)[1] + 3
         y += h + row_gap
 
@@ -2958,15 +2961,13 @@ def _draw_status_png(
         draw.line((pad, y, width - pad, y), fill=border, width=1)
         y += 12
         for line in _wrap_text(draw, footer, font_foot, content_w):
-            draw.text((pad, y), line, font=font_foot, fill=accent)
+            _draw_text(draw, (pad, y), line, font_foot, accent)
             y += _text_size(draw, line or " ", font_foot)[1] + 2
 
     if style.show_brand:
         brand = "hapi connector"
         bw, bh = _text_size(draw, brand, font_foot)
-        draw.text(
-            (width - pad - bw, height - pad - bh), brand, font=font_foot, fill=sub_fg
-        )
+        _draw_text(draw, (width - pad - bw, height - pad - bh), brand, font_foot, sub_fg)
 
     buf = io.BytesIO()
     img.save(buf, format="PNG", optimize=True)
@@ -3080,11 +3081,11 @@ def _draw_session_list_png(
     draw = ImageDraw.Draw(img)
 
     y = pad
-    draw.text((pad, y), title, font=font_title, fill=fg)
+    _draw_text(draw, (pad, y), title, font_title, fg)
     y += _text_size(draw, title, font_title)[1] + 6
     if subtitle:
         for line in _wrap_text(draw, subtitle, font_sub, content_w):
-            draw.text((pad, y), line, font=font_sub, fill=sub_fg)
+            _draw_text(draw, (pad, y), line, font_sub, sub_fg)
             y += _text_size(draw, line or " ", font_sub)[1] + 2
         y += 6
     draw.rectangle((pad, y, pad + min(140, content_w // 3), y + 4), fill=accent)
@@ -3112,13 +3113,13 @@ def _draw_session_list_png(
             tx = pad + 14
             ty = y + (sec_h - _text_size(draw, "测", font_meta)[1]) // 2
             for line in _wrap_text(draw, label, font_meta, content_w - 90)[:1]:
-                draw.text((tx, ty), line, font=font_meta, fill=accent)
+                _draw_text(draw, (tx, ty), line, font_meta, accent)
             if count_txt:
                 badge = f"{count_txt} 个" if not str(count_txt).endswith("个") else str(count_txt)
                 bw, bh = _text_size(draw, badge, font_meta)
                 bx = width - pad - bw - 12
                 by = y + (sec_h - bh) // 2
-                draw.text((bx, by), badge, font=font_meta, fill=sub_fg)
+                _draw_text(draw, (bx, by), badge, font_meta, sub_fg)
             y += sec_h + 8
             continue
 
@@ -3172,17 +3173,18 @@ def _draw_session_list_png(
         )
         ix = idx_box_left + (idx_box_w - tw) // 2 - toff_x
         iy = idx_box_top + (idx_box_h - th) // 2 - toff_y
-        draw.text(
+        _draw_text(
+            draw,
             (ix, iy),
             idx_txt,
-            font=font_idx,
-            fill=accent if is_current else sub_fg,
+            font_idx,
+            accent if is_current else sub_fg,
         )
 
         tx = pad + row_pad_x + idx_box_w + 12
         ty = y + row_pad_y
         for line in title_lines:
-            draw.text((tx, ty), line, font=font_body, fill=fg)
+            _draw_text(draw, (tx, ty), line, font_body, fg)
             ty += _text_size(draw, line or " ", font_body)[1] + 3
 
         sc = _status_color(status_key, accent, muted, fg)
@@ -3196,15 +3198,16 @@ def _draw_session_list_png(
             m_th, m_toff = meta_h, 0
         cy = my - m_toff + m_th // 2 + 10
         draw.ellipse((tx, cy - dot_r, tx + dot_r * 2, cy + dot_r), fill=sc)
-        draw.text((tx + 14, my), meta_line, font=font_meta, fill=sub_fg)
+        _draw_text(draw, (tx + 14, my), meta_line, font_meta, sub_fg)
 
         if sid:
             sw, sh = _text_size(draw, sid, font_meta)
-            draw.text(
+            _draw_text(
+                draw,
                 (width - pad - row_pad_x - sw, y + row_pad_y),
                 sid,
-                font=font_meta,
-                fill=sub_fg,
+                font_meta,
+                sub_fg,
             )
 
         y += row_h + row_gap
@@ -3214,7 +3217,7 @@ def _draw_session_list_png(
         draw.line((pad, y, width - pad, y), fill=border, width=1)
         y += 12
         for line in _wrap_text(draw, footer, font_foot, content_w):
-            draw.text((pad, y), line, font=font_foot, fill=accent)
+            _draw_text(draw, (pad, y), line, font_foot, accent)
             y += _text_size(draw, line or " ", font_foot)[1] + 2
 
     # 按实际内容高度裁剪多余空白；若内容超出预估则扩展
@@ -3353,11 +3356,11 @@ def _draw_struct_png(
     draw = ImageDraw.Draw(img)
 
     y = pad
-    draw.text((pad, y), title, font=font_title, fill=fg)
+    _draw_text(draw, (pad, y), title, font_title, fg)
     y += _text_size(draw, title, font_title)[1] + 6
     if subtitle:
         for line in _wrap_text(draw, subtitle, font_sub, content_w):
-            draw.text((pad, y), line, font=font_sub, fill=muted)
+            _draw_text(draw, (pad, y), line, font_sub, muted)
             y += _text_size(draw, line or " ", font_sub)[1] + 2
         y += 8
     draw.rectangle((pad, y, pad + min(120, content_w // 3), y + 3), fill=accent)
@@ -3369,7 +3372,7 @@ def _draw_struct_png(
         detail = str(row.get("detail") or "")
         if rtype == "section":
             for line in _wrap_text(draw, head, font_sub, content_w):
-                draw.text((pad, y), line, font=font_sub, fill=accent)
+                _draw_text(draw, (pad, y), line, font_sub, accent)
                 y += _text_size(draw, line or " ", font_sub)[1] + 2
             y += row_gap // 2
             continue
@@ -3391,10 +3394,10 @@ def _draw_struct_png(
         )
         yy = y + row_pad_y
         for line in head_lines:
-            draw.text((pad + 10, yy), line, font=font_body, fill=fg)
+            _draw_text(draw, (pad + 10, yy), line, font_body, fg)
             yy += _text_size(draw, line or " ", font_body)[1] + 2
         for line in detail_lines:
-            draw.text((pad + 14, yy), line, font=font_sub, fill=muted)
+            _draw_text(draw, (pad + 14, yy), line, font_sub, muted)
             yy += _text_size(draw, line or " ", font_sub)[1] + 2
         y += block_h + row_gap
 
@@ -3403,7 +3406,7 @@ def _draw_struct_png(
         draw.line((pad, y, width - pad, y), fill=border, width=1)
         y += foot_gap_after
         for line in _wrap_text(draw, footer, font_foot, content_w):
-            draw.text((pad, y), line, font=font_foot, fill=accent)
+            _draw_text(draw, (pad, y), line, font_foot, accent)
             y += _text_size(draw, line or " ", font_foot)[1] + 3
 
     brand_h = 0
@@ -3428,11 +3431,12 @@ def _draw_struct_png(
     if style.show_brand:
         brand = "hapi connector"
         bw, bh = _text_size(draw, brand, font_foot)
-        draw.text(
+        _draw_text(
+            draw,
             (width - pad - bw, height - pad - bh),
             brand,
-            font=font_foot,
-            fill=muted,
+            font_foot,
+            muted,
         )
 
     # 外框最后画，避免扩展后丢失
@@ -3940,11 +3944,11 @@ def _draw_message_png(
     )
 
     y = pad
-    draw.text((pad, y), title, font=font_title, fill=fg)
+    _draw_text(draw, (pad, y), title, font_title, fg)
     y += _text_size(draw, title, font_title)[1] + 8
     if subtitle:
         for line in _wrap_text(draw, subtitle, font_sub, content_w):
-            draw.text((pad, y), line, font=font_sub, fill=sub_fg)
+            _draw_text(draw, (pad, y), line, font_sub, sub_fg)
             y += _text_size(draw, line or " ", font_sub)[1] + line_extra
         y += 8
     draw.rectangle((pad, y, pad + min(160, content_w // 3), y + 4), fill=accent)
@@ -3977,7 +3981,7 @@ def _draw_message_png(
                     try:
                         img.paste(im, (x, yy))
                     except Exception:
-                        draw.text((x, y), str(p.get("text") or ""), font=font_body, fill=fg)
+                        _draw_text(draw, (x, y), str(p.get("text") or ""), font_body, fg)
                     x += im.width + 3
                 else:
                     t = str(p.get("text") or "")
@@ -4062,14 +4066,14 @@ def _draw_message_png(
                     for line in _wrap_text(
                         draw, str(b.get("text") or ""), font_body, content_w
                     ):
-                        draw.text((pad, y), line, font=font_body, fill=fg)
+                        _draw_text(draw, (pad, y), line, font_body, fg)
                         y += _text_size(draw, line or " ", font_body)[1] + line_extra
                     y += 8
             else:
                 for line in _wrap_text(
                     draw, str(b.get("text") or ""), font_body, content_w
                 ):
-                    draw.text((pad, y), line, font=font_body, fill=fg)
+                    _draw_text(draw, (pad, y), line, font_body, fg)
                     y += _text_size(draw, line or " ", font_body)[1] + line_extra
                 y += 8
             continue
@@ -4128,7 +4132,7 @@ def _draw_message_png(
             if not inner_blocks:
                 body = str(b.get("text") or "")
                 for ln in _wrap_text(draw, body, font_body, inner_w) or [""]:
-                    draw.text((text_x, yy), ln, font=font_body, fill=fg)
+                    _draw_text(draw, (text_x, yy), ln, font_body, fg)
                     yy += _text_size(draw, ln or " ", font_body)[1] + line_loose
             else:
                 for idx, ib in enumerate(inner_blocks):
@@ -4182,7 +4186,7 @@ def _draw_message_png(
                                 col = _hex_to_rgb(style.diff_add)
                             elif s.startswith("-"):
                                 col = _hex_to_rgb(style.diff_del)
-                            draw.text((text_x + 10, dyy), ln, font=font_code, fill=col)
+                            _draw_text(draw, (text_x + 10, dyy), ln, font_code, col)
                             dyy += _text_size(draw, ln or " ", font_code)[1] + 4
                         yy += ih + inner_gap
                     elif ibt == "code":
@@ -4211,14 +4215,14 @@ def _draw_message_png(
                         )
                         cyy = yy + 8
                         for ln in clines:
-                            draw.text((text_x + 10, cyy), ln, font=font_code, fill=fg)
+                            _draw_text(draw, (text_x + 10, cyy), ln, font_code, fg)
                             cyy += _text_size(draw, ln or " ", font_code)[1] + 4
                         yy += ch + inner_gap
                     else:
                         prefix = "●  " if ibt == "li" else ""
                         raw = prefix + str(ib.get("text") or "")
                         for ln in _wrap_text(draw, raw, font_body, inner_w) or [""]:
-                            draw.text((text_x, yy), ln, font=font_body, fill=fg)
+                            _draw_text(draw, (text_x, yy), ln, font_body, fg)
                             yy += (
                                 _text_size(draw, ln or " ", font_body)[1] + line_loose
                             )
@@ -4296,7 +4300,7 @@ def _draw_message_png(
                     col = add_fg
                 elif s.startswith("-"):
                     col = del_fg
-                draw.text((text_x, yy), ln, font=font_code, fill=col)
+                _draw_text(draw, (text_x, yy), ln, font_code, col)
                 yy += _text_size(draw, ln or " ", font_code)[1] + 3
             y += block_h + tool_gap
             continue
@@ -4309,7 +4313,7 @@ def _draw_message_png(
             for ln in _wrap_text(draw, line, font_body, content_w - 16) or [""]:
                 # 完成项略淡
                 col = _mix_rgb(fg, muted, 0.35) if status == "done" else mark_fg
-                draw.text((pad + 8, y), ln, font=font_body, fill=col)
+                _draw_text(draw, (pad + 8, y), ln, font_body, col)
                 y += _text_size(draw, ln or " ", font_body)[1] + line_extra
             y += 4
             continue
@@ -4336,7 +4340,7 @@ def _draw_message_png(
             )
             yy = y + 10
             for line in lines:
-                draw.text((pad + 12, yy), line, font=font_code, fill=fg)
+                _draw_text(draw, (pad + 12, yy), line, font_code, fg)
                 yy += _text_size(draw, line or " ", font_code)[1] + line_extra
             y += block_h + 12
             continue
@@ -4506,12 +4510,12 @@ def _draw_message_png(
                     y += im.height + 18
                 except Exception:
                     for line in _wrap_text(draw, f"[图片] {alt}", font_body, content_w):
-                        draw.text((pad, y), line, font=font_body, fill=sub_fg)
+                        _draw_text(draw, (pad, y), line, font_body, sub_fg)
                         y += _text_size(draw, line or " ", font_body)[1] + line_extra
                     y += 8
             else:
                 for line in _wrap_text(draw, f"[图片] {alt}", font_body, content_w):
-                    draw.text((pad, y), line, font=font_body, fill=sub_fg)
+                    _draw_text(draw, (pad, y), line, font_body, sub_fg)
                     y += _text_size(draw, line or " ", font_body)[1] + line_extra
                 y += 8
             continue
@@ -4548,7 +4552,7 @@ def _draw_message_png(
                 img = bigger
                 draw = ImageDraw.Draw(img)
                 height = need
-            draw.text((pad, y), line, font=font_foot, fill=accent)
+            _draw_text(draw, (pad, y), line, font_foot, accent)
             y += _text_size(draw, line or " ", font_foot)[1] + line_extra + 2
 
     brand_h = 0
@@ -4571,9 +4575,7 @@ def _draw_message_png(
     if style.show_brand:
         brand = "hapi connector"
         bw, bh = _text_size(draw, brand, font_foot)
-        draw.text(
-            (width - pad - bw, height - pad - bh), brand, font=font_foot, fill=sub_fg
-        )
+        _draw_text(draw, (width - pad - bw, height - pad - bh), brand, font_foot, sub_fg)
 
     # 外框最后画，扩展后不丢边框
     _draw_rounded_rect(

--- a/render/font_manager.py
+++ b/render/font_manager.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import unicodedata
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,20 @@ _SYSTEM_MONO = (
     "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
     "C:\\Windows\\Fonts\\consola.ttf",
     "/System/Library/Fonts/Menlo.ttc",
+)
+
+_SYSTEM_FALLBACKS = (
+    # Windows supplementary CJK and symbol fonts.
+    "C:\\Windows\\Fonts\\SimsunExtG.ttf",
+    "C:\\Windows\\Fonts\\NotoSansSC-VF.ttf",
+    "C:\\Windows\\Fonts\\NotoSerifSC-VF.ttf",
+    "C:\\Windows\\Fonts\\seguisym.ttf",
+    "C:\\Windows\\Fonts\\segoeui.ttf",
+    "C:\\Windows\\Fonts\\arial.ttf",
+    # Common Linux symbol/CJK fallbacks.
+    "/usr/share/fonts/truetype/noto/NotoSansSymbols2-Regular.ttf",
+    "/usr/share/fonts/truetype/noto/NotoSansSymbols-Regular.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
 )
 
 
@@ -350,6 +365,77 @@ def load_image_font(
                 if try_path.suffix.lower() not in (".ttc", ".otc"):
                     break
     raise RuntimeError(f"无法加载字体 {path}: {last_err}")
+
+
+@lru_cache(maxsize=32)
+def _load_fallback_fonts(size: int) -> tuple[Any, ...]:
+    """Load optional system fonts used for characters absent from the card font."""
+    from PIL import ImageFont
+
+    fonts = []
+    for raw_path in _SYSTEM_FALLBACKS:
+        path = Path(raw_path)
+        try:
+            if not path.is_file() or path.stat().st_size <= 1024:
+                continue
+            fonts.append(ImageFont.truetype(str(path), size=size))
+        except (OSError, ValueError):
+            continue
+    return tuple(fonts)
+
+
+def _glyph_signature(font: Any, character: str) -> tuple[Any, bytes]:
+    mask = font.getmask(character)
+    return mask.size, bytes(mask)
+
+
+def _font_supports(font: Any, text: str) -> bool:
+    """Return whether a font maps every visible character to a real glyph."""
+    try:
+        missing = {
+            _glyph_signature(font, "\u0378"),
+            _glyph_signature(font, "\U0010FFFF"),
+        }
+        for character in text:
+            if character.isspace() or unicodedata.category(character) in {"Cc", "Cf"}:
+                continue
+            if _glyph_signature(font, character) in missing:
+                return False
+        return True
+    except (OSError, TypeError, UnicodeError, ValueError):
+        return False
+
+
+def get_font_runs(text: str, primary_font: Any) -> list[tuple[str, Any]]:
+    """Split text into runs whose fonts contain the required glyphs.
+
+    Combining marks and variation selectors remain attached to their base
+    character so a fallback font can render the complete visible cluster.
+    """
+    if not text:
+        return []
+    size = max(1, int(getattr(primary_font, "size", 16)))
+    candidates = (primary_font, *_load_fallback_fonts(size))
+    clusters: list[str] = []
+    for character in text:
+        if clusters and (
+            unicodedata.combining(character)
+            or character == "\u200d"
+            or 0xFE00 <= ord(character) <= 0xFE0F
+            or 0xE0100 <= ord(character) <= 0xE01EF
+        ):
+            clusters[-1] += character
+        else:
+            clusters.append(character)
+
+    runs: list[tuple[str, Any]] = []
+    for cluster in clusters:
+        font = next((candidate for candidate in candidates if _font_supports(candidate, cluster)), primary_font)
+        if runs and runs[-1][1] is font:
+            runs[-1] = (runs[-1][0] + cluster, font)
+        else:
+            runs.append((cluster, font))
+    return runs
 
 
 def _source_label(src: str | None) -> str:

--- a/tests/test_font_fallback.py
+++ b/tests/test_font_fallback.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+
+from render import card_render, font_manager
+
+
+class _Mask:
+    def __init__(self, value: bytes):
+        self.size = (1, 1)
+        self.value = value
+
+    def __bytes__(self):
+        return self.value
+
+
+class _Font:
+    size = 16
+
+    def __init__(self, supported: set[str]):
+        self.supported = supported
+
+    def getmask(self, text: str):
+        return _Mask(b"g" if text in self.supported else b"?")
+
+
+class _Draw:
+    def __init__(self):
+        self.calls = []
+
+    def textbbox(self, _xy, text, *, font, **_kwargs):
+        return (0, 0, len(text) * 10, 16)
+
+    def text(self, xy, text, **kwargs):
+        self.calls.append((xy, text, kwargs["font"]))
+
+
+class FontFallbackTests(unittest.TestCase):
+    def test_get_font_runs_switches_only_for_missing_glyphs(self):
+        primary = _Font(set("AB"))
+        fallback = _Font({"𰻞"})
+
+        with patch.object(font_manager, "_load_fallback_fonts", return_value=(fallback,)):
+            runs = font_manager.get_font_runs("A𰻞B", primary)
+
+        self.assertEqual(runs, [("A", primary), ("𰻞", fallback), ("B", primary)])
+
+    def test_draw_text_keeps_run_widths_aligned(self):
+        primary = _Font(set("AB"))
+        fallback = _Font({"𰻞"})
+        draw = _Draw()
+
+        with patch.object(font_manager, "_load_fallback_fonts", return_value=(fallback,)):
+            card_render._draw_text(draw, (4, 8), "A𰻞B", primary, (0, 0, 0))
+
+        self.assertEqual([call[1] for call in draw.calls], ["A", "𰻞", "B"])
+        self.assertEqual([call[0][0] for call in draw.calls], [4, 14, 24])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Detect missing-glyph boxes from the selected Pillow font and split text into runs with available system fallback fonts.
- Apply the same fallback-aware measurement and drawing to structured cards and Markdown message cards.
- Add platform-independent regression tests for mixed-font runs and horizontal alignment.

## Root cause

The renderer used one selected font for every code point. Characters outside that font's cmap were rendered as Pillow's missing-glyph box, while some direct card drawing paths bypassed the existing text helper.

## Testing

- python -m unittest discover -s tests -p 'test_*.py' -v`n- python -m compileall -q render tests`n- Real Pillow render with CJK extension characters and symbols produced a valid PNG.

Ruff still reports five pre-existing issues in the current branch, unrelated to this change.